### PR TITLE
Feat: 문제집 생성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,8 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation:3.3.0")
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+	implementation("org.springframework.boot:spring-boot-starter-validation:3.3.0")
+
 
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,6 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation:3.3.0")
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
-	implementation("org.springframework.boot:spring-boot-starter-validation:3.3.0")
 
 
 }

--- a/src/main/kotlin/com/swm_standard/phote/common/authority/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/authority/JwtAuthenticationFilter.kt
@@ -23,7 +23,7 @@ class JwtAuthenticationFilter(
     }
 
     private fun resolveToken(request: HttpServletRequest): String? {
-        val bearerToken = request.getHeader("Authorization")
+        val bearerToken = request.getHeader("accessToken")
 
         return if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
             bearerToken.substring(7)

--- a/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
@@ -21,7 +21,7 @@ class CustomExceptionHandler {
             errors[fieldName] = errorMessage ?: "Not Exception Message"
         }
 
-        return ResponseEntity(BaseResponse(ResultCode.ERROR.name, ResultCode.ERROR.statusCode, ResultCode.ERROR.msg, errors), HttpStatus.BAD_REQUEST)
+        return ResponseEntity(BaseResponse(ResultCode.BAD_REQUEST.name, ResultCode.BAD_REQUEST.statusCode, ResultCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
     }
 
     @ExceptionHandler(InvalidInputException::class)

--- a/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
@@ -37,4 +37,11 @@ class CustomExceptionHandler {
         return ResponseEntity(BaseResponse(ResultCode.ERROR.name, ResultCode.ERROR.statusCode, ResultCode.ERROR.msg, errors), HttpStatus.BAD_REQUEST)
 
     }
+
+    @ExceptionHandler(NullPointerException::class)
+    protected fun nullPointerException(ex: Exception) : ResponseEntity<BaseResponse<Map<String?, String>>> {
+        val errors = mapOf(ex.message to (ex.message ?: "Not Exception Message"))
+        return ResponseEntity(BaseResponse(ResultCode.ERROR.name, ResultCode.ERROR.statusCode, ResultCode.ERROR.msg, errors), HttpStatus.BAD_REQUEST)
+
+    }
 }

--- a/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
@@ -1,0 +1,30 @@
+package com.swm_standard.phote.controller
+
+import com.swm_standard.phote.common.responsebody.BaseResponse
+import com.swm_standard.phote.dto.WorkbookCreationRequest
+import com.swm_standard.phote.dto.WorkbookCreationResponse
+import com.swm_standard.phote.entity.Workbook
+import com.swm_standard.phote.service.WorkbookService
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.*
+
+@RestController
+@RequestMapping("/api")
+class WorkbookController(private val workbookService: WorkbookService) {
+
+    @PostMapping("/workbook")
+    fun createWorkbook(@RequestBody request: WorkbookCreationRequest, authentication: Authentication): BaseResponse<WorkbookCreationResponse> {
+
+        val workbook = workbookService.createWorkbook(
+            request.title,
+            request.description,
+            authentication.name
+        )
+
+        return BaseResponse(msg = "문제집 생성 성공", data = workbook)
+    }
+}

--- a/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
@@ -1,27 +1,27 @@
 package com.swm_standard.phote.controller
 
 import com.swm_standard.phote.common.responsebody.BaseResponse
-import com.swm_standard.phote.dto.WorkbookCreationRequest
-import com.swm_standard.phote.dto.WorkbookCreationResponse
-import com.swm_standard.phote.entity.Workbook
+import com.swm_standard.phote.dto.CreateWorkbookRequest
+import com.swm_standard.phote.dto.CreateWorkbookResponse
 import com.swm_standard.phote.service.WorkbookService
+import jakarta.validation.Valid
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.*
 
 @RestController
 @RequestMapping("/api")
 class WorkbookController(private val workbookService: WorkbookService) {
 
     @PostMapping("/workbook")
-    fun createWorkbook(@RequestBody request: WorkbookCreationRequest, authentication: Authentication): BaseResponse<WorkbookCreationResponse> {
+    fun createWorkbook(@Valid @RequestBody request: CreateWorkbookRequest, authentication: Authentication): BaseResponse<CreateWorkbookResponse> {
 
         val workbook = workbookService.createWorkbook(
             request.title,
             request.description,
+            request.emoji,
             authentication.name
         )
 

--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -1,0 +1,22 @@
+package com.swm_standard.phote.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import jakarta.validation.constraints.NotBlank
+import java.util.UUID
+
+data class WorkbookCreationRequest(
+    @field:NotBlank
+    @JsonProperty("title")
+    private val _title: String?,
+
+    @JsonProperty("description")
+    private val _description: String?,
+) {
+    val title: String get() = _title!!
+
+    val description: String get() = _description ?: ""
+}
+
+data class WorkbookCreationResponse(
+    val id: UUID
+)

--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -4,19 +4,24 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotBlank
 import java.util.UUID
 
-data class WorkbookCreationRequest(
-    @field:NotBlank
+data class CreateWorkbookRequest(
+    @field:NotBlank(message = "문제집 이름을 입력해주세요.")
     @JsonProperty("title")
     private val _title: String?,
 
     @JsonProperty("description")
     private val _description: String?,
+
+    @JsonProperty("emoji")
+    private val _emoji: String?,
 ) {
     val title: String get() = _title!!
 
     val description: String get() = _description ?: ""
+
+    val emoji: String get() = _emoji ?: "📚"
 }
 
-data class WorkbookCreationResponse(
+data class CreateWorkbookResponse(
     val id: UUID
 )

--- a/src/main/kotlin/com/swm_standard/phote/entity/Member.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Member.kt
@@ -13,7 +13,7 @@ data class Member(
     val physicalId: Long,
 
     @Column(name = "member_uuid", nullable = false, unique = true)
-    val id: UUID,
+    val id: UUID = UUID.randomUUID(),
 
     val name: String,
 

--- a/src/main/kotlin/com/swm_standard/phote/entity/WorkBook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/WorkBook.kt
@@ -10,36 +10,41 @@ import java.util.*
 @Entity
 data class Workbook(
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "workbook_id")
-    val physicalId: Long,
+    var title: String,
 
-    @Column(name = "workbook_uuid", nullable = false, unique = true)
-    val id: UUID,
-
-    val title: String,
-
-    val description: String?,
+    var description: String?,
 
     @ManyToOne
     @JoinColumn(name = "member_id")
-    val member: Member,
+    val member: Member
+
+){
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "workbook_id")
+    val physicalId: Long = 0
+
+    @Column(name = "workbook_uuid", nullable = false, unique = true)
+    val id: UUID = UUID.randomUUID()
 
     @OneToMany(mappedBy = "workbook")
     @OrderBy("order asc")
-    val questionSet: Set<QuestionSet>?,
+    val questionSet: Set<QuestionSet>? = null
 
-    val emoji: String,
+    var emoji: String = ""
 
     @ColumnDefault(value = "0")
-    val quantity: Int,
+    var quantity: Int = 0
 
     @CreationTimestamp
-    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val createdAt: LocalDateTime = LocalDateTime.now()
 
-    val deletedAt: LocalDateTime?,
+    val deletedAt: LocalDateTime? = null
 
     @LastModifiedDate
-    val modifiedAt: LocalDateTime?
+    var modifiedAt: LocalDateTime? = null
 
-    )
+
+
+
+}

--- a/src/main/kotlin/com/swm_standard/phote/entity/WorkBook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/WorkBook.kt
@@ -16,7 +16,9 @@ data class Workbook(
 
     @ManyToOne
     @JoinColumn(name = "member_id")
-    val member: Member
+    val member: Member,
+
+    var emoji: String?,
 
 ){
 
@@ -31,8 +33,6 @@ data class Workbook(
     @OrderBy("order asc")
     val questionSet: Set<QuestionSet>? = null
 
-    var emoji: String = ""
-
     @ColumnDefault(value = "0")
     var quantity: Int = 0
 
@@ -43,8 +43,5 @@ data class Workbook(
 
     @LastModifiedDate
     var modifiedAt: LocalDateTime? = null
-
-
-
 
 }

--- a/src/main/kotlin/com/swm_standard/phote/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/MemberRepository.kt
@@ -1,0 +1,11 @@
+package com.swm_standard.phote.repository
+
+import com.swm_standard.phote.entity.Member
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MemberRepository : JpaRepository<Member, Long> {
+
+    fun findByEmail(email: String): Member?
+}

--- a/src/main/kotlin/com/swm_standard/phote/repository/WorkbookRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/WorkbookRepository.kt
@@ -1,0 +1,7 @@
+package com.swm_standard.phote.repository
+
+import com.swm_standard.phote.entity.Workbook
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface WorkbookRepository: JpaRepository<Workbook, Long> {
+}

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -1,0 +1,22 @@
+package com.swm_standard.phote.service
+
+import com.swm_standard.phote.dto.WorkbookCreationResponse
+import com.swm_standard.phote.entity.Workbook
+import com.swm_standard.phote.repository.MemberRepository
+import com.swm_standard.phote.repository.WorkbookRepository
+import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class WorkbookService(
+    private val workbookRepository: WorkbookRepository,
+    private val memberRepository: MemberRepository
+) {
+
+    fun createWorkbook(title: String, description: String?, memberEmail: String): WorkbookCreationResponse {
+        val member = memberRepository.findByEmail(memberEmail) ?: throw NotFoundException()
+        val workbook = workbookRepository.save(Workbook(title, description, member))
+
+        return WorkbookCreationResponse(workbook.id)
+    }
+}

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -1,6 +1,6 @@
 package com.swm_standard.phote.service
 
-import com.swm_standard.phote.dto.WorkbookCreationResponse
+import com.swm_standard.phote.dto.CreateWorkbookResponse
 import com.swm_standard.phote.entity.Workbook
 import com.swm_standard.phote.repository.MemberRepository
 import com.swm_standard.phote.repository.WorkbookRepository
@@ -13,10 +13,10 @@ class WorkbookService(
     private val memberRepository: MemberRepository
 ) {
 
-    fun createWorkbook(title: String, description: String?, memberEmail: String): WorkbookCreationResponse {
+    fun createWorkbook(title: String, description: String?, emoji: String?, memberEmail: String): CreateWorkbookResponse {
         val member = memberRepository.findByEmail(memberEmail) ?: throw NotFoundException()
-        val workbook = workbookRepository.save(Workbook(title, description, member))
+        val workbook = workbookRepository.save(Workbook(title, description, member, emoji))
 
-        return WorkbookCreationResponse(workbook.id)
+        return CreateWorkbookResponse(workbook.id)
     }
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 문제집 생성 기능을 구현함


### ✨ 참고 사항

- 현재는 `authentication.name` 에 member email이 담겨 있어서 findByEmail로 문제집 생성자를 할당하고 있는데, `authentication.name` 에 memberId (UUID) 가 담기는게 더 낫지 않을까 고민입니당
-  @RinRinPARK 근데 어제 말한 UserResolver ? 를 사용하면 거기서 사용자 정보도 처리할 수 있는거려나??
- 현재 문제집 생성 성공 응답에 생성된 문제 id만 담는데 더 추가할게 있으면 알려주세요


### ✅ 응답 예시


<img width="499" alt="스크린샷 2024-07-08 오후 12 43 16" src="https://github.com/swm-standard/Phote_BE/assets/90397541/8c1c6152-696d-4caa-972a-9ee963b6143e">


---

### ⏰ 현재 버그

x

---

### ✏ Git Close #7 