### PR TITLE
Fix: 응답 코드 enum 변경

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
@@ -1,7 +1,7 @@
 package com.swm_standard.phote.common.exception
 
 import com.swm_standard.phote.common.responsebody.BaseResponse
-import com.swm_standard.phote.common.responsebody.ResultCode
+import com.swm_standard.phote.common.responsebody.ErrorCode
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.FieldError
@@ -21,20 +21,27 @@ class CustomExceptionHandler {
             errors[fieldName] = errorMessage ?: "Not Exception Message"
         }
 
-        return ResponseEntity(BaseResponse(ResultCode.ERROR.name, ResultCode.ERROR.statusCode, ResultCode.ERROR.msg, errors), HttpStatus.BAD_REQUEST)
+        return ResponseEntity(BaseResponse(ErrorCode.ERROR.name, ErrorCode.BAD_REQUEST.statusCode, ErrorCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
     }
 
     @ExceptionHandler(InvalidInputException::class)
     protected fun invalidInputException(ex: InvalidInputException) : ResponseEntity<BaseResponse<Map<String, String>>> {
         val errors = mapOf(ex.fieldName to (ex.message ?: "Not Exception Message"))
-        return ResponseEntity(BaseResponse(ResultCode.BAD_REQUEST.name, ResultCode.BAD_REQUEST.statusCode, ResultCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
+        return ResponseEntity(BaseResponse(ErrorCode.ERROR.name, ErrorCode.BAD_REQUEST.statusCode, ErrorCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
 
     }
 
     @ExceptionHandler(Exception::class)
     protected fun defaultException(ex: Exception) : ResponseEntity<BaseResponse<Map<String, String>>> {
         val errors = mapOf("미처리 에러" to (ex.message ?: "Not Exception Message"))
-        return ResponseEntity(BaseResponse(ResultCode.ERROR.name, ResultCode.ERROR.statusCode, ResultCode.ERROR.msg, errors), HttpStatus.BAD_REQUEST)
+        return ResponseEntity(BaseResponse(ErrorCode.ERROR.name, ErrorCode.ERROR.statusCode, ErrorCode.ERROR.msg, errors), HttpStatus.BAD_REQUEST)
+
+    }
+
+    @ExceptionHandler(NullPointerException::class)
+    protected fun nullPointerException(ex: Exception) : ResponseEntity<BaseResponse<Map<String?, String>>> {
+        val errors = mapOf(ex.message to (ex.message ?: "Not Exception Message"))
+        return ResponseEntity(BaseResponse(ErrorCode.ERROR.name, ErrorCode.ERROR.statusCode, ErrorCode.ERROR.msg, errors), HttpStatus.BAD_REQUEST)
 
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/common/responsebody/BaseResponse.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/responsebody/BaseResponse.kt
@@ -1,8 +1,8 @@
 package com.swm_standard.phote.common.responsebody
 
 data class BaseResponse<T>(
-    val result: String = ResultCode.SUCCESS.name,
-    val status: Int = ResultCode.SUCCESS.statusCode,
-    val msg: String = ResultCode.SUCCESS.msg,
+    val result: String = SuccessCode.SUCCESS.name,
+    val status: Int = SuccessCode.SUCCESS.statusCode,
+    val msg: String = SuccessCode.SUCCESS.msg,
     val data: T? = null,
 )

--- a/src/main/kotlin/com/swm_standard/phote/common/responsebody/EnumStatus.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/responsebody/EnumStatus.kt
@@ -2,8 +2,11 @@ package com.swm_standard.phote.common.responsebody
 
 import org.springframework.http.HttpStatus
 
-enum class ResultCode(val statusCode: Int, val msg: String) {
+enum class SuccessCode(val statusCode: Int, val msg: String) {
     SUCCESS(HttpStatus.OK.value(),"정상 처리 되었습니다."),
+}
+
+enum class ErrorCode(val statusCode: Int, val msg: String) {
     ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(),"에러가 발생했습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "요청 값이 올바르지 않습니다.")
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- 응답코드 enum을 SuccessCode, ErrorCode 로 나눔
- ResponseBody의 result 는 SUCCESS 또는 ERROR 로만 나타내도록 변경함 
---

### ✨ 참고 사항

x

---

### ⏰ 현재 버그

x

---

### ✏ Git Close #17 