### PR TITLE
문제집 정보 상세 읽기 (Seyeon/swm 41)

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
@@ -8,6 +8,7 @@ import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.resource.NoResourceFoundException
 
 @RestControllerAdvice
 class CustomExceptionHandler {
@@ -43,5 +44,11 @@ class CustomExceptionHandler {
         val errors = mapOf(ex.message to (ex.message ?: "Not Exception Message"))
         return ResponseEntity(BaseResponse(ResultCode.ERROR.name, ResultCode.ERROR.statusCode, ResultCode.ERROR.msg, errors), HttpStatus.BAD_REQUEST)
 
+    }
+
+    @ExceptionHandler(NoResourceFoundException::class)
+    protected fun noResourceException(ex: Exception) : ResponseEntity<BaseResponse<Map<String?, String>>> {
+        val errors = mapOf(ex.message to (ex.message ?: "Not Exception Message"))
+        return ResponseEntity(BaseResponse(ResultCode.ERROR.name, ResultCode.BAD_REQUEST.statusCode, ResultCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
@@ -1,9 +1,11 @@
 package com.swm_standard.phote.controller
 
+import com.fasterxml.jackson.databind.ser.Serializers.Base
 import com.swm_standard.phote.common.responsebody.BaseResponse
 import com.swm_standard.phote.dto.DeleteWorkbookResponse
 import com.swm_standard.phote.dto.CreateWorkbookRequest
 import com.swm_standard.phote.dto.CreateWorkbookResponse
+import com.swm_standard.phote.dto.ReadWorkbookDetailResponse
 import com.swm_standard.phote.service.WorkbookService
 import jakarta.validation.Valid
 import org.springframework.security.core.Authentication
@@ -33,5 +35,12 @@ class WorkbookController(private val workbookService: WorkbookService) {
         val deletedWorkbook = workbookService.deleteWorkbook(id)
 
         return BaseResponse(msg = "문제집 삭제 성공", data = deletedWorkbook)
+    }
+
+    @GetMapping("/workbook/{workbookId}")
+    fun readWorkbookDetail(@Valid @PathVariable workbookId: UUID): BaseResponse<ReadWorkbookDetailResponse> {
+        val workbookDetail = workbookService.readWorkbookDetail(workbookId)
+
+        return BaseResponse(msg = "문제집 정보 읽기 성공", data = workbookDetail)
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -1,6 +1,7 @@
 package com.swm_standard.phote.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.swm_standard.phote.entity.QuestionSet
 import jakarta.validation.constraints.NotBlank
 import java.time.LocalDateTime
 import java.util.UUID
@@ -31,4 +32,20 @@ data class DeleteWorkbookResponse(
     val id: UUID,
 
     val deletedAt: LocalDateTime
+)
+
+data class ReadWorkbookDetailResponse(
+    val id: UUID,
+
+    val title: String,
+
+    val description: String?,
+
+    val emoji: String,
+
+    val createdAt: LocalDateTime,
+
+    val modifiedAt: LocalDateTime?,
+
+    val questions: List<QuestionSet>,
 )

--- a/src/main/kotlin/com/swm_standard/phote/entity/Member.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Member.kt
@@ -1,5 +1,6 @@
 package com.swm_standard.phote.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.*
 import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDateTime
@@ -27,6 +28,7 @@ data class Member(
     @CreationTimestamp
     val joinedAt: LocalDateTime = LocalDateTime.now(),
 
+    @JsonIgnore
     val deletedAt: LocalDateTime?
 )
 

--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -1,5 +1,6 @@
 package com.swm_standard.phote.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.*
 import org.hibernate.annotations.CreationTimestamp
 import org.springframework.data.annotation.LastModifiedDate
@@ -11,6 +12,7 @@ import java.util.*
 data class Question(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "question_id")
+    @JsonIgnore
     val physicalId: Long,
 
     @Column(name = "question_uuid", nullable = false, unique = true)
@@ -18,6 +20,7 @@ data class Question(
 
     @ManyToOne(cascade = [(CascadeType.REMOVE)])
     @JoinColumn(name = "member_id")
+    @JsonIgnore
     val member: Member,
 
     @Lob
@@ -43,6 +46,7 @@ data class Question(
     @CreationTimestamp
     val createdAt: LocalDateTime = LocalDateTime.now(),
 
+    @JsonIgnore
     val deletedAt: LocalDateTime?,
 
     @LastModifiedDate

--- a/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
@@ -1,5 +1,6 @@
 package com.swm_standard.phote.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.*
 import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDateTime
@@ -16,11 +17,14 @@ data class QuestionSet(
 
     @ManyToOne
     @JoinColumn(name = "workbook_id")
+    @JsonIgnore
     val workbook: Workbook,
 
     val sequence: Int,
 
     @CreationTimestamp
     val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @JsonIgnore
     val deletedAt: LocalDateTime?,
     )

--- a/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
@@ -1,5 +1,6 @@
 package com.swm_standard.phote.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.*
 import org.hibernate.annotations.ColumnDefault
 import org.hibernate.annotations.CreationTimestamp
@@ -16,6 +17,7 @@ data class Workbook(
 
     @ManyToOne
     @JoinColumn(name = "member_id")
+    @JsonIgnore
     val member: Member,
 
     var emoji: String?,
@@ -24,14 +26,15 @@ data class Workbook(
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "workbook_id")
+    @JsonIgnore
     val physicalId: Long = 0
 
     @Column(name = "workbook_uuid", nullable = false, unique = true)
     val id: UUID = UUID.randomUUID()
 
     @OneToMany(mappedBy = "workbook")
-    @OrderBy("order asc")
-    val questionSet: Set<QuestionSet>? = null
+    @OrderBy("sequence asc")
+    val questionSet: List<QuestionSet>? = null
 
     @ColumnDefault(value = "0")
     var quantity: Int = 0
@@ -39,6 +42,7 @@ data class Workbook(
     @CreationTimestamp
     val createdAt: LocalDateTime = LocalDateTime.now()
 
+    @JsonIgnore
     var deletedAt: LocalDateTime? = null
 
     @LastModifiedDate

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionRepository.kt
@@ -1,0 +1,9 @@
+package com.swm_standard.phote.repository
+
+import com.swm_standard.phote.entity.Question
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface QuestionRepository: JpaRepository<Question, UUID> {
+
+}

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetRepository.kt
@@ -1,0 +1,12 @@
+package com.swm_standard.phote.repository
+
+import com.swm_standard.phote.entity.QuestionSet
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface QuestionSetRepository: JpaRepository<QuestionSet, Long> {
+
+    fun findAllByWorkbookId(workbookId:UUID): List<QuestionSet>
+
+
+}

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -2,8 +2,11 @@ package com.swm_standard.phote.service
 
 import com.swm_standard.phote.dto.CreateWorkbookResponse
 import com.swm_standard.phote.dto.DeleteWorkbookResponse
+import com.swm_standard.phote.dto.ReadWorkbookDetailResponse
 import com.swm_standard.phote.entity.Workbook
 import com.swm_standard.phote.repository.MemberRepository
+import com.swm_standard.phote.repository.QuestionRepository
+import com.swm_standard.phote.repository.QuestionSetRepository
 import com.swm_standard.phote.repository.WorkbookRepository
 import jakarta.transaction.Transactional
 import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException
@@ -14,7 +17,9 @@ import java.util.UUID
 @Service
 class WorkbookService(
     private val workbookRepository: WorkbookRepository,
-    private val memberRepository: MemberRepository
+    private val memberRepository: MemberRepository,
+    private val questionRepository: QuestionRepository,
+    private val questionSetRepository: QuestionSetRepository
 ) {
 
     fun createWorkbook(title: String, description: String?, emoji: String?, memberEmail: String): CreateWorkbookResponse {
@@ -33,5 +38,20 @@ class WorkbookService(
         val deletedWorkbook = workbookRepository.save(workbook)
 
         return DeleteWorkbookResponse(deletedWorkbook.id, deletedWorkbook.deletedAt!!)
+    }
+
+    fun readWorkbookDetail(id: UUID) : ReadWorkbookDetailResponse {
+        val workbook = workbookRepository.findWorkbookById(id) ?: throw NotFoundException()
+        val questionSet = questionSetRepository.findAllByWorkbookId(id)
+
+        return ReadWorkbookDetailResponse(
+            workbook.id,
+            workbook.title,
+            workbook.description,
+            workbook.emoji!!,
+            workbook.createdAt,
+            workbook.modifiedAt,
+            questionSet
+            )
     }
 }

--- a/src/test/kotlin/com/swm_standard/phote/service/WorkbookServiceTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/service/WorkbookServiceTest.kt
@@ -1,0 +1,68 @@
+package com.swm_standard.phote.service
+
+import com.swm_standard.phote.entity.Member
+import com.swm_standard.phote.entity.Provider
+import com.swm_standard.phote.entity.Workbook
+import com.swm_standard.phote.repository.QuestionSetRepository
+import com.swm_standard.phote.repository.WorkbookRepository
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.DisplayName
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import java.time.LocalDateTime
+import java.util.UUID
+
+class WorkbookServiceTest (
+    @Mock private val workbookRepository: WorkbookRepository,
+    @Mock private val questionSetRepository: QuestionSetRepository,
+    @InjectMocks private val sut: WorkbookService
+){
+
+    @Test
+    @DisplayName("문제집 상세 정보 읽기에 성공한다.")
+    fun readWorkbookDetail() {
+        val workbook = createMockWorkbook()
+        val uuid = workbook.id
+        Mockito.`when`(workbookRepository.findWorkbookById(uuid)).thenReturn(workbook)
+        Mockito.`when`(questionSetRepository.findById(1L)).thenReturn(null)
+
+        val response = sut.readWorkbookDetail(uuid)
+
+        Assertions.assertThat(response.title).isEqualTo(workbook.title)
+        Assertions.assertThat(response.description).isEqualTo(workbook.description)
+    }
+
+    fun createMockWorkbook(
+        title: String = "Sample Workbook",
+        description: String? = "Sample Description",
+        member: Member = createMockMember(),
+        emoji: String? = "😊",
+        quantity: Int = 10
+    ): Workbook {
+        val workbook = Workbook(
+            title = title,
+            description = description,
+            member = member,
+            emoji = emoji,
+        )
+        workbook.quantity = quantity
+        return workbook
+    }
+
+    private fun createMockMember(): Member {
+        return Member(
+            email = "test@example.com",
+            name = "Test User",
+            provider = Provider.GOOGLE,
+            id = UUID.randomUUID(),
+            joinedAt = LocalDateTime.now(),
+            image = "example.com",
+            deletedAt = null,
+            physicalId = 1L,
+
+        )
+    }
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 문제집 상세정보 읽기를 구현함

---

### ✨ 참고 사항

- `deletedAt`,  `member` 필드 등은 @JsonIgnore 처리함

### ✅ 응답 예시

#### 성공 시
![스크린샷 2024-07-08 오후 6 26 21](https://github.com/swm-standard/Phote_BE/assets/90397541/7a818a14-06ae-4d51-987e-3c14bd590ad7)

### 실패 시
![스크린샷 2024-07-08 오후 6 26 31](https://github.com/swm-standard/Phote_BE/assets/90397541/fe61fc64-2f52-4bd0-84fa-ef3356c248d0)



---

### ⏰ 현재 버그

- `workbookId` 가 아예 안들어오면 id가 Null임을 알려주고 싶은데 `NoResourceFoundException` 예외가 발생해서 방법을 못찾고 있음

---

### ✏ Git Close #14 