### PR TITLE
Fix: JPA 엔티티 PK 수정

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/entity/Member.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Member.kt
@@ -9,11 +9,7 @@ import java.util.UUID
 @Entity
 data class Member(
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "member_id")
-    val physicalId: Long,
-
-    @Column(name = "member_uuid", nullable = false, unique = true)
+    @Id @Column(name = "member_uuid", nullable = false, unique = true)
     val id: UUID = UUID.randomUUID(),
 
     val name: String,

--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -10,12 +10,8 @@ import java.util.*
 
 @Entity
 data class Question(
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "question_id")
-    @JsonIgnore
-    val physicalId: Long,
 
-    @Column(name = "question_uuid", nullable = false, unique = true)
+    @Id @Column(name = "question_uuid", nullable = false, unique = true)
     val id: UUID,
 
     @ManyToOne(cascade = [(CascadeType.REMOVE)])

--- a/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
@@ -24,12 +24,7 @@ data class Workbook(
 
 ){
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "workbook_id")
-    @JsonIgnore
-    val physicalId: Long = 0
-
-    @Column(name = "workbook_uuid", nullable = false, unique = true)
+    @Id @Column(name = "workbook_uuid", nullable = false, unique = true)
     val id: UUID = UUID.randomUUID()
 
     @OneToMany(mappedBy = "workbook")
@@ -37,7 +32,7 @@ data class Workbook(
     val questionSet: List<QuestionSet>? = null
 
     @ColumnDefault(value = "0")
-    var quantity: Int = 0
+    var quantity: Int? = null
 
     @CreationTimestamp
     val createdAt: LocalDateTime = LocalDateTime.now()


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- `Member`, `Question`, `Workbook` 엔티티의 physical Id 삭제
---

### ✨ 참고 사항

- DB 상에서는 존재하고 JPA 에서만 삭제하는 프로퍼티입니당

---

### ⏰ 현재 버그

x

---

### ✏ Git Close #26 