### PR TITLE
Feat: DeleteQuestion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,9 +38,6 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("io.jsonwebtoken:jjwt-api:0.11.5")
 	implementation("org.springframework.boot:spring-boot-starter-validation:3.3.0")
-	implementation ("org.springframework.cloud:spring-cloud-starter-bootstrap:3.1.3")
-	implementation ("org.springframework.cloud:spring-cloud-starter-aws-secrets-manager-config:2.2.6.RELEASE")
-	implementation ("com.amazonaws.secretsmanager:aws-secretsmanager-jdbc:1.0.8")
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 

--- a/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
@@ -65,7 +65,7 @@ class CustomExceptionHandler {
     @ExceptionHandler(AlreadyDeletedException::class)
     protected fun alreadyDeletedException(ex: AlreadyDeletedException) : ResponseEntity<BaseResponse<Map<String, String>>> {
         val errors = mapOf(ex.fieldName to (ex.message ?: "Not Exception Message"))
-        return ResponseEntity(BaseResponse(ErrorCode.ERROR.name, ErrorCode.ERROR.statusCode, ErrorCode.ERROR.msg, errors), HttpStatus.BAD_REQUEST)
+        return ResponseEntity(BaseResponse(ErrorCode.BAD_REQUEST.name, ErrorCode.BAD_REQUEST.statusCode, ErrorCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
 
     }
 

--- a/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
@@ -1,7 +1,5 @@
 package com.swm_standard.phote.controller
 
-import com.swm_standard.phote.common.exception.InvalidInputException
-import com.swm_standard.phote.common.resolver.memberId.MemberId
 import com.swm_standard.phote.common.responsebody.BaseResponse
 import com.swm_standard.phote.dto.DeleteQuestionResponseDto
 import com.swm_standard.phote.dto.ReadQuestionDetailResponseDto

--- a/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
@@ -1,12 +1,11 @@
 package com.swm_standard.phote.controller
 
-import com.swm_standard.phote.common.exception.InvalidInputException
 import com.swm_standard.phote.common.responsebody.BaseResponse
-import com.swm_standard.phote.dto.response.ReadQuestionDetailResponseDto
-import com.swm_standard.phote.repository.QuestionRepository
+import com.swm_standard.phote.dto.DeleteQuestionResponseDto
+import com.swm_standard.phote.dto.ReadQuestionDetailResponseDto
 import com.swm_standard.phote.service.QuestionService
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -25,5 +24,11 @@ class QuestionController {
     ) id: UUID
     ): BaseResponse<ReadQuestionDetailResponseDto> {
         return BaseResponse(msg = "문제 상세조회 성공", data = questionService.readQuestionDetail(id))
+    }
+
+    @DeleteMapping("/question/{id}")
+    fun deleteQuestion(@PathVariable(required = true) id: UUID)
+    : BaseResponse<DeleteQuestionResponseDto>{
+        return BaseResponse(msg = "문제 삭제 성공", data = questionService.deleteQuestion(id))
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
@@ -11,7 +11,7 @@ data class ReadQuestionDetailResponseDto(
     val statement: String,
     val image: String? = null,
     val options: JsonNode? = null,
-    val answer: String?,
+    val answer: String,
     val category: String,
     val memo: String? = null
 ) {

--- a/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
@@ -1,7 +1,9 @@
-package com.swm_standard.phote.dto.response
+package com.swm_standard.phote.dto
+
 import com.fasterxml.jackson.databind.JsonNode
 import com.swm_standard.phote.entity.Question
 import java.time.LocalDateTime
+import java.util.*
 
 data class ReadQuestionDetailResponseDto(
     val createdAt: LocalDateTime,
@@ -9,7 +11,7 @@ data class ReadQuestionDetailResponseDto(
     val statement: String,
     val image: String? = null,
     val options: JsonNode? = null,
-    val answer: String,
+    val answer: String?,
     val category: String,
     val memo: String? = null
 ) {
@@ -24,3 +26,8 @@ data class ReadQuestionDetailResponseDto(
         memo = question.memo
     )
 }
+
+class DeleteQuestionResponseDto (
+    val id: UUID,
+    val deletedAt: LocalDateTime
+)

--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -47,9 +47,9 @@ data class Question(
     val createdAt: LocalDateTime = LocalDateTime.now(),
 
     @JsonIgnore
-    val deletedAt: LocalDateTime?,
+    var deletedAt: LocalDateTime?,
 
     @LastModifiedDate
-    val modifiedAt: LocalDateTime?,
+    var modifiedAt: LocalDateTime?,
 
     )

--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -30,7 +30,7 @@ data class Question(
 
     val image: String?,
 
-    val answer: String?,
+    val answer: String,
 
     val category: String,
 

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionRepository.kt
@@ -2,9 +2,18 @@ package com.swm_standard.phote.repository
 
 import com.swm_standard.phote.entity.Question
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 import java.util.*
 
 @Repository
 interface QuestionRepository: JpaRepository<Question, UUID> {
+    @Query("UPDATE Question q SET q.deletedAt = CURRENT_TIMESTAMP WHERE q.id = :id")
+    @Modifying
+    override fun deleteById(id: UUID)
+
+    @Query("SELECT q.deletedAt FROM Question q WHERE q.id = :id")
+    fun findDeletedAtById(id: UUID): LocalDateTime
 }

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionRepository.kt
@@ -10,10 +10,4 @@ import java.util.*
 
 @Repository
 interface QuestionRepository: JpaRepository<Question, UUID> {
-    @Query("UPDATE Question q SET q.deletedAt = CURRENT_TIMESTAMP WHERE q.id = :id")
-    @Modifying
-    override fun deleteById(id: UUID)
-
-    @Query("SELECT q.deletedAt FROM Question q WHERE q.id = :id")
-    fun findDeletedAtById(id: UUID): LocalDateTime
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -3,11 +3,14 @@ package com.swm_standard.phote.service
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.swm_standard.phote.common.exception.BadRequestException
 import com.swm_standard.phote.common.exception.NotFoundException
-import com.swm_standard.phote.dto.response.ReadQuestionDetailResponseDto
+import com.swm_standard.phote.dto.DeleteQuestionResponseDto
+import com.swm_standard.phote.dto.ReadQuestionDetailResponseDto
 import com.swm_standard.phote.repository.QuestionRepository
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Service
@@ -21,5 +24,15 @@ class QuestionService (private val questionRepository: QuestionRepository) {
         val questionOptionsObject: JsonNode = objectMapper.readTree(question.options)
 
         return ReadQuestionDetailResponseDto(question, questionOptionsObject)
+    }
+
+    @Transactional
+    fun deleteQuestion(id: UUID): DeleteQuestionResponseDto {
+        val question = questionRepository.findById(id).orElseThrow { NotFoundException("존재하지 않는 UUID") }
+        if (question.deletedAt != null) throw BadRequestException("이미 삭제된 question")
+
+        // deleteAt필드 채우기
+        questionRepository.deleteById(id)
+        return DeleteQuestionResponseDto(id, questionRepository.findDeletedAtById(id))
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -32,7 +32,9 @@ class QuestionService (private val questionRepository: QuestionRepository) {
         if (question.deletedAt != null) throw BadRequestException("이미 삭제된 question")
 
         // deleteAt필드 채우기
-        questionRepository.deleteById(id)
-        return DeleteQuestionResponseDto(id, questionRepository.findDeletedAtById(id))
+        question.deletedAt = LocalDateTime.now()
+        questionRepository.save(question)
+
+        return DeleteQuestionResponseDto(id, question.deletedAt!!)
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -2,6 +2,7 @@ package com.swm_standard.phote.service
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.swm_standard.phote.common.exception.AlreadyDeletedException
 import com.swm_standard.phote.common.exception.BadRequestException
 import com.swm_standard.phote.common.exception.NotFoundException
 import com.swm_standard.phote.dto.DeleteQuestionResponseDto
@@ -28,7 +29,7 @@ class QuestionService (private val questionRepository: QuestionRepository) {
     @Transactional
     fun deleteQuestion(id: UUID): DeleteQuestionResponseDto {
         val question = questionRepository.findById(id).orElseThrow { NotFoundException("존재하지 않는 UUID") }
-        if (question.deletedAt != null) throw BadRequestException("이미 삭제된 question")
+        if (question.deletedAt != null) throw AlreadyDeletedException()
 
         // deleteAt필드 채우기
         question.deletedAt = LocalDateTime.now()

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -2,7 +2,6 @@ package com.swm_standard.phote.service
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.swm_standard.phote.common.exception.BadRequestException
 import com.swm_standard.phote.common.exception.NotFoundException
 import com.swm_standard.phote.dto.DeleteQuestionResponseDto


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- soft delete방식으로 deleteQuestion api를 구현했습니다.
---

### ✨ 참고 사항
- 처음에는 question의 deletedAt을 업데이트하고, response에 question의 deletedAt을 다시 참조해서 값을 불러오는 방식을 생각했으나 굳이 쿼리를 두번 쓰는건 좀.. 아닌거 같아서 수정했습니다.
---

### ⏰ 현재 버그

---

### ✏ Git Close #10 