### PR TITLE
FIX: readQuestionDetail 데이터 필드가 없을 때 안불러지는 오류

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/dto/response/ReadQuestionDetailResponseDto.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/response/ReadQuestionDetailResponseDto.kt
@@ -9,7 +9,7 @@ data class ReadQuestionDetailResponseDto(
     val statement: String,
     val image: String? = null,
     val options: JsonNode? = null,
-    val answer: String?,
+    val answer: String,
     val category: String,
     val memo: String? = null
 ) {
@@ -19,6 +19,16 @@ data class ReadQuestionDetailResponseDto(
         statement = question.statement,
         image = question.image,
         options = options,
+        answer = question.answer,
+        category = question.category,
+        memo = question.memo
+    )
+
+    constructor(question: Question) : this(
+        createdAt = question.createdAt,
+        modifiedAt = question.modifiedAt,
+        statement = question.statement,
+        image = question.image,
         answer = question.answer,
         category = question.category,
         memo = question.memo

--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.*
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.annotations.SQLRestriction
 import org.hibernate.type.SqlTypes
 import org.springframework.data.annotation.LastModifiedDate
 import java.time.LocalDateTime
@@ -11,6 +12,7 @@ import java.util.*
 
 
 @Entity
+@SQLRestriction("deleted_at is NULL")
 data class Question(
 
     @Id @Column(name = "question_uuid", nullable = false, unique = true)

--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -26,11 +26,11 @@ data class Question(
 
     @Column(columnDefinition = "json")
     @JdbcTypeCode(SqlTypes.JSON)
-    val options: String,
+    val options: String?,
 
     val image: String?,
 
-    val answer: String?,
+    val answer: String,
 
     val category: String,
 

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -16,10 +16,16 @@ class QuestionService (private val questionRepository: QuestionRepository) {
     fun readQuestionDetail(id: UUID): ReadQuestionDetailResponseDto {
         val question = questionRepository.findById(id).orElseThrow { NotFoundException("존재하지 않는 UUID") }
 
-        // string type으로 오는 options를 deserialize
-        val objectMapper = ObjectMapper()
-        val questionOptionsObject: JsonNode = objectMapper.readTree(question.options)
+        // options가 있는 객관식일 경우
+        if (question.options != null) {
+            // string type으로 오는 options를 deserialize
+            val objectMapper = ObjectMapper()
+            val questionOptionsObject: JsonNode = objectMapper.readTree(question.options)
 
-        return ReadQuestionDetailResponseDto(question, questionOptionsObject)
+            return ReadQuestionDetailResponseDto(question, questionOptionsObject)
+        }
+
+        // options가 없는 주관식일 경우
+        return ReadQuestionDetailResponseDto(question)
     }
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 문제 상세 조회 시, options가 null인 경우 에러가 나는 버그를 해결했습니다.
- 문제 상세 조회 시, 삭제된 문제인지 확인하는 로직이 없어 삭제되는 문제도 조회되는 버그를 해결했습니다.
---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close #35 