### PR TITLE
Fix: readWorkbookDetail 관련 오류 (exception 처리, 기삭제된 문제집)

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
@@ -41,12 +41,6 @@ class CustomExceptionHandler {
 
     }
 
-    @ExceptionHandler(NullPointerException::class)
-    protected fun nullPointerException(ex: Exception) : ResponseEntity<BaseResponse<Map<String?, String>>> {
-        val errors = mapOf(ex.message to (ex.message ?: "Not Exception Message"))
-        return ResponseEntity(BaseResponse(ErrorCode.ERROR.name, ErrorCode.ERROR.statusCode, ErrorCode.ERROR.msg, errors), HttpStatus.BAD_REQUEST)
-
-    }
 
     @ExceptionHandler(BadRequestException::class)
     protected fun badRequestException(ex: BadRequestException) : ResponseEntity<BaseResponse<Map<String, String>>> {
@@ -57,8 +51,8 @@ class CustomExceptionHandler {
 
 
     @ExceptionHandler(NoResourceFoundException::class)
-    protected fun noResourceException(ex: Exception) : ResponseEntity<BaseResponse<Map<String?, String>>> {
-        val errors = mapOf(ex.message to (ex.message ?: "Not Exception Message"))
+    protected fun noResourceException(ex: Exception) : ResponseEntity<BaseResponse<Map<String, String>>> {
+        val errors = mapOf("id" to (ex.message ?: "Not Exception Message"))
         return ResponseEntity(BaseResponse(ErrorCode.ERROR.name, ErrorCode.BAD_REQUEST.statusCode, ErrorCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
     }
 

--- a/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
@@ -37,7 +37,7 @@ class WorkbookController(private val workbookService: WorkbookService) {
     }
 
     @GetMapping("/workbook/{workbookId}")
-    fun readWorkbookDetail(@Valid @PathVariable workbookId: UUID): BaseResponse<ReadWorkbookDetailResponse> {
+    fun readWorkbookDetail(@Valid @PathVariable(required = true) workbookId: UUID): BaseResponse<ReadWorkbookDetailResponse> {
 
         val workbookDetail = workbookService.readWorkbookDetail(workbookId)
 

--- a/src/main/kotlin/com/swm_standard/phote/dto/QuestionSetDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/QuestionSetDtos.kt
@@ -1,0 +1,9 @@
+package com.swm_standard.phote.dto
+
+import com.swm_standard.phote.entity.Question
+
+data class QuestionSetDto(
+    val sequence: Int,
+
+    val question: Question
+)

--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -1,7 +1,6 @@
 package com.swm_standard.phote.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.swm_standard.phote.entity.QuestionSet
 import jakarta.validation.constraints.NotBlank
 import java.time.LocalDateTime
 import java.util.UUID
@@ -47,5 +46,5 @@ data class ReadWorkbookDetailResponse(
 
     val modifiedAt: LocalDateTime?,
 
-    val questions: List<QuestionSet>,
+    val questions: List<QuestionSetDto>,
 )

--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -38,6 +38,7 @@ data class Question(
     val category: String,
 
     @OneToMany(mappedBy = "question")
+    @JsonIgnore
     val questionSet: Set<QuestionSet>?,
 
     @JoinColumn(name = "tag_id", nullable = true)

--- a/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
@@ -26,7 +26,7 @@ data class QuestionSet(
     val createdAt: LocalDateTime = LocalDateTime.now(),
 
     @JsonIgnore
-    val deletedAt: LocalDateTime?,
+    var deletedAt: LocalDateTime?,
     ) {
 
     fun isDeleted():Boolean = this.deletedAt != null

--- a/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
@@ -27,4 +27,7 @@ data class QuestionSet(
 
     @JsonIgnore
     val deletedAt: LocalDateTime?,
-    )
+    ) {
+
+    fun isDeleted():Boolean = this.deletedAt != null
+}

--- a/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
@@ -44,4 +44,6 @@ data class Workbook(
     @Column(updatable = false)
     var modifiedAt: LocalDateTime? = null
 
+
+    fun isDeleted():Boolean = this.deletedAt != null
 }

--- a/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
@@ -41,7 +41,6 @@ data class Workbook(
     var deletedAt: LocalDateTime? = null
 
     @LastModifiedDate
-    @Column(updatable = false)
     var modifiedAt: LocalDateTime? = null
 
 

--- a/src/main/kotlin/com/swm_standard/phote/repository/WorkbookRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/WorkbookRepository.kt
@@ -5,6 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.util.*
 
 interface WorkbookRepository: JpaRepository<Workbook, UUID> {
-
-    fun findWorkbookById(id: UUID): Workbook?
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -31,7 +31,7 @@ class WorkbookService(
     @Transactional
     fun deleteWorkbook(id: UUID): DeleteWorkbookResponse {
         val workbook = workbookRepository.findById(id).orElseThrow { NotFoundException("존재하지 않는 workbook") }
-        if (workbook.deletedAt != null) throw AlreadyDeletedException("workbook")
+        if (workbook.isDeleted()) throw AlreadyDeletedException("workbook")
 
         workbook.deletedAt = LocalDateTime.now()
         val deletedWorkbook = workbookRepository.save(workbook)
@@ -41,7 +41,7 @@ class WorkbookService(
 
     fun readWorkbookDetail(id: UUID) : ReadWorkbookDetailResponse {
         val workbook = workbookRepository.findById(id).orElseThrow { NotFoundException(message = "존재하지 않는 workbook") }
-        if (workbook.deletedAt != null) throw AlreadyDeletedException("workbook")
+        if (workbook.isDeleted()) throw AlreadyDeletedException("workbook")
 
         val questionSet = questionSetRepository.findAllByWorkbookId(id)
 

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -4,6 +4,7 @@ import com.swm_standard.phote.common.exception.AlreadyDeletedException
 import com.swm_standard.phote.common.exception.NotFoundException
 import com.swm_standard.phote.dto.CreateWorkbookResponse
 import com.swm_standard.phote.dto.DeleteWorkbookResponse
+import com.swm_standard.phote.dto.QuestionSetDto
 import com.swm_standard.phote.dto.ReadWorkbookDetailResponse
 import com.swm_standard.phote.entity.Workbook
 import com.swm_standard.phote.repository.MemberRepository
@@ -45,6 +46,13 @@ class WorkbookService(
 
         val questionSet = questionSetRepository.findAllByWorkbookId(id)
 
+        val questionSetDto: List<QuestionSetDto> = questionSet.filter { !it.isDeleted() }.map { set ->
+            QuestionSetDto(
+                set.sequence,
+                set.question
+            )
+        }
+
         return ReadWorkbookDetailResponse(
             workbook.id,
             workbook.title,
@@ -52,7 +60,7 @@ class WorkbookService(
             workbook.emoji!!,
             workbook.createdAt,
             workbook.modifiedAt,
-            questionSet
+            questionSetDto
             )
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -1,6 +1,7 @@
 package com.swm_standard.phote.service
 
 import com.swm_standard.phote.common.exception.AlreadyDeletedException
+import com.swm_standard.phote.common.exception.NotFoundException
 import com.swm_standard.phote.dto.CreateWorkbookResponse
 import com.swm_standard.phote.dto.DeleteWorkbookResponse
 import com.swm_standard.phote.dto.ReadWorkbookDetailResponse
@@ -9,7 +10,6 @@ import com.swm_standard.phote.repository.MemberRepository
 import com.swm_standard.phote.repository.QuestionSetRepository
 import com.swm_standard.phote.repository.WorkbookRepository
 import jakarta.transaction.Transactional
-import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.UUID
@@ -40,7 +40,7 @@ class WorkbookService(
     }
 
     fun readWorkbookDetail(id: UUID) : ReadWorkbookDetailResponse {
-        val workbook = workbookRepository.findWorkbookById(id) ?: throw NotFoundException()
+        val workbook = workbookRepository.findWorkbookById(id) ?: throw NotFoundException(message = "존재하지 않는 workbook")
         val questionSet = questionSetRepository.findAllByWorkbookId(id)
 
         return ReadWorkbookDetailResponse(

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -30,7 +30,7 @@ class WorkbookService(
 
     @Transactional
     fun deleteWorkbook(id: UUID): DeleteWorkbookResponse {
-        val workbook = workbookRepository.findWorkbookById(id) ?: throw NotFoundException()
+        val workbook = workbookRepository.findById(id).orElseThrow { NotFoundException("존재하지 않는 workbook") }
         if (workbook.deletedAt != null) throw AlreadyDeletedException("workbook")
 
         workbook.deletedAt = LocalDateTime.now()
@@ -40,7 +40,9 @@ class WorkbookService(
     }
 
     fun readWorkbookDetail(id: UUID) : ReadWorkbookDetailResponse {
-        val workbook = workbookRepository.findWorkbookById(id) ?: throw NotFoundException(message = "존재하지 않는 workbook")
+        val workbook = workbookRepository.findById(id).orElseThrow { NotFoundException(message = "존재하지 않는 workbook") }
+        if (workbook.deletedAt != null) throw AlreadyDeletedException("workbook")
+
         val questionSet = questionSetRepository.findAllByWorkbookId(id)
 
         return ReadWorkbookDetailResponse(

--- a/src/test/kotlin/com/swm_standard/phote/entity/WorkbookTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/WorkbookTest.kt
@@ -1,0 +1,30 @@
+package com.swm_standard.phote.entity
+
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import java.time.LocalDateTime
+import java.util.*
+
+class WorkbookTest {
+
+    @Test
+    fun `이미 삭제된 문제에 접근할 수 없다`() {
+        val workbook = Workbook(
+            title = "cubilia", description = null, member = Member(
+                id = UUID.randomUUID(),
+                name = "Fern Duran",
+                email = "ricky.holloway@example.com",
+                image = "consectetuer",
+                provider = Provider.APPLE,
+                joinedAt = LocalDateTime.now(),
+                deletedAt = null
+            ), emoji = null
+        )
+        workbook.deletedAt = LocalDateTime.now()
+
+
+        assertEquals(workbook.isDeleted(), true)
+
+    }
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- **readWorkbookDetail 무효 id exception 처리**


1️⃣ 문제집 id가 유효하지 않을 때 (uuid 형식이 아닐 때)
<img width="300" alt="스크린샷 2024-07-10 오후 5 44 34" src="https://github.com/swm-standard/Phote_BE/assets/90397541/a702982a-d079-4f2e-8692-a3d4bb5532b1">

2️⃣ 이미 삭제된 문제집일 때
<img width="300" alt="스크린샷 2024-07-10 오후 5 45 50" src="https://github.com/swm-standard/Phote_BE/assets/90397541/02f44ab2-be9a-4d66-b8d3-8ea32f51af40">

3️⃣ 문제집 id가 path variable에 없을 때
<img width="300" alt="스크린샷 2024-07-10 오후 5 46 26" src="https://github.com/swm-standard/Phote_BE/assets/90397541/48a78594-923b-47c5-8ff0-8b14e035347b">


- **이미 삭제된 문제집 상세 조회 막기**
➡️ 이 부분에서 비즈니스 로직을 Workbook 엔티티 클래스 내부로 넣어봤습니당 (`isdeleted()`)


> ✅ ✅ `SQLRestriction` 을 사용한게 좋은 것 같아서 차용해보려다가 custom으로 만들어둔 `AlreadyDeletedException` 을 사용해야 해서 그냥 deletedAt 체크하는걸로 구현했습니다. (쿼리 요청 횟수는 같더라구요!)

- **삭제 여부 test 완료**
---

### ✨ 참고 사항

#### [c06c9b8](https://github.com/swm-standard/Phote_BE/pull/47/commits/c06c9b8a6c1d47ebf9794ccee17303bbe54192c6) 커밋 관련 참고 사항
(@RinRinPARK question 쪽에서 구현할 때 한번 확인해주세용)

- 문제집 내에서 문제 삭제 여부 확인 후 `QuestionSetDto`로 변환함

> ✅question이 삭제될 경우 해당 questionSet은 함께 soft delete된다고 생각해서 question 실제 삭제 여부는 따지지 않음

- Workbook 내의 QuestionSet 을 dto로 감싸지 않으면 `isDeleted` 메서드가 json에 결과와 함께 출력됨 -> 메서드 제외용 dto를 만듦

> ✅api에 직접적인 연관이 없어서 단순 엔티티명 + dto 로 `QuestionSetDto` 라고 이름 붙임 

---

### ⏰ 현재 버그

x

---

### ✏ Git Close #40 