### PR TITLE
Fix: deleteQuestion시 QuestionSet도 삭제

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -15,8 +15,8 @@ import java.util.*
 @SQLRestriction("deleted_at is NULL")
 data class Question(
 
-    @Id @GeneratedValue(strategy = GenerationType.UUID)
-    val id: UUID,
+    @Id @Column(name = "question_uuid", nullable = false, unique = true)
+    val id: UUID = UUID.randomUUID(),
 
 
     @ManyToOne(cascade = [(CascadeType.REMOVE)])

--- a/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
@@ -26,5 +26,5 @@ data class QuestionSet(
     val createdAt: LocalDateTime = LocalDateTime.now(),
 
     @JsonIgnore
-    val deletedAt: LocalDateTime?,
+    var deletedAt: LocalDateTime?,
     )

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetRepository.kt
@@ -2,11 +2,17 @@ package com.swm_standard.phote.repository
 
 import com.swm_standard.phote.entity.QuestionSet
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDateTime
 import java.util.UUID
 
 interface QuestionSetRepository: JpaRepository<QuestionSet, UUID> {
 
     fun findAllByWorkbookId(workbookId:UUID): List<QuestionSet>
 
+    @Modifying
+    @Query("UPDATE QuestionSet qs SET qs.deletedAt = :deletedAt WHERE qs.question.id = :questionId")
+    fun markDeletedByQuestionId(questionId: UUID, deletedAt: LocalDateTime)
 
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -46,8 +46,11 @@ class QuestionService (
         questionSetRepository.markDeletedByQuestionId(id, now)
 
         // deletedAt필드 채우기
-        question.deletedAt = now
-        questionRepository.save(question)
+        question.apply {
+            deletedAt = now
+        }.also {
+            questionRepository.save(it)
+        }
 
         return DeleteQuestionResponseDto(id, question.deletedAt!!)
     }

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -8,13 +8,16 @@ import com.swm_standard.phote.common.exception.NotFoundException
 import com.swm_standard.phote.dto.DeleteQuestionResponseDto
 import com.swm_standard.phote.dto.ReadQuestionDetailResponseDto
 import com.swm_standard.phote.repository.QuestionRepository
+import com.swm_standard.phote.repository.QuestionSetRepository
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.UUID
 
 @Service
-class QuestionService (private val questionRepository: QuestionRepository) {
+class QuestionService (
+    private val questionRepository: QuestionRepository,
+    private val questionSetRepository: QuestionSetRepository) {
     @Transactional
     fun readQuestionDetail(id: UUID): ReadQuestionDetailResponseDto {
         val question = questionRepository.findById(id).orElseThrow { NotFoundException("존재하지 않는 UUID") }
@@ -37,8 +40,13 @@ class QuestionService (private val questionRepository: QuestionRepository) {
         val question = questionRepository.findById(id).orElseThrow { NotFoundException("존재하지 않는 UUID") }
         if (question.deletedAt != null) throw AlreadyDeletedException()
 
-        // deleteAt필드 채우기
-        question.deletedAt = LocalDateTime.now()
+        val now = LocalDateTime.now()
+
+        // workbook과의 관계 끊어주기
+        questionSetRepository.markDeletedByQuestionId(id, now)
+
+        // deletedAt필드 채우기
+        question.deletedAt = now
         questionRepository.save(question)
 
         return DeleteQuestionResponseDto(id, question.deletedAt!!)

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -38,7 +38,6 @@ class QuestionService (
     @Transactional
     fun deleteQuestion(id: UUID): DeleteQuestionResponseDto {
         val question = questionRepository.findById(id).orElseThrow { NotFoundException("존재하지 않는 UUID") }
-        if (question.deletedAt != null) throw AlreadyDeletedException()
 
         val now = LocalDateTime.now()
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- deleteQuestion 시, Question Set 엔티티 내 레코드가 삭제되지 않는 버그 수정
---

### ✨ 참고 사항
- 기존 deleteQuestion을 최대한 코틀린 문법을 활용해보고자.. ㅋㅋ scope function을 이용해 리팩해봤습니다
- AlreadyDeletedException을 삭제했습니다.
  - Question엔티티에 ```@SQLRestriction("deleted_at is NULL")```을 걸어놔서 deletedAt이 null이 아닌 레코드는 걍 
  ```val question = questionRepository.findById(id).orElseThrow { NotFoundException("존재하지 않는 UUID") }```여기서 notFound해버리더라구용
그래서 ```@SQLRestriction("deleted_at is NULL")```을 지우고 AlreadyDeletedException을 살릴까 했는데, 
그러면 나중에 문제 리스트 조회같은걸 할 때 deletedAt이 null인걸 다 확인하고 빼주는 작업을 해야할 것 같아서 걍 Already어쩌구를 지웠습니다.

---

### ⏰ 현재 버그

---

### ✏ Git Close #48 