### PR TITLE
Fix: Workbook 삭제 시 연관된 QuestionSet 도 삭제

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -1,6 +1,7 @@
 package com.swm_standard.phote.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.swm_standard.phote.entity.QuestionSet
 import jakarta.validation.constraints.NotBlank
 import java.time.LocalDateTime
 import java.util.UUID
@@ -46,5 +47,5 @@ data class ReadWorkbookDetailResponse(
 
     val modifiedAt: LocalDateTime?,
 
-    val questions: List<QuestionSetDto>,
+    val questions: List<QuestionSet>,
 )

--- a/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
@@ -3,9 +3,13 @@ package com.swm_standard.phote.entity
 import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.*
 import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
 import java.time.LocalDateTime
 
 @Entity
+@SQLDelete(sql = "UPDATE question_set SET deleted_at = NOW() WHERE question_set_id = ?")
+@SQLRestriction("deleted_at is NULL")
 data class QuestionSet(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "questionSet_id")
@@ -27,7 +31,4 @@ data class QuestionSet(
 
     @JsonIgnore
     var deletedAt: LocalDateTime?,
-    ) {
-
-    fun isDeleted():Boolean = this.deletedAt != null
-}
+    )

--- a/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
@@ -4,11 +4,15 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.*
 import org.hibernate.annotations.ColumnDefault
 import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
 import org.springframework.data.annotation.LastModifiedDate
 import java.time.LocalDateTime
 import java.util.*
 
 @Entity
+@SQLDelete(sql = "UPDATE workbook SET deleted_at = NOW() WHERE workbook_uuid = ?")
+@SQLRestriction("deleted_at is NULL")
 data class Workbook(
 
     var title: String,
@@ -27,7 +31,7 @@ data class Workbook(
     @Id @Column(name = "workbook_uuid", nullable = false, unique = true)
     val id: UUID = UUID.randomUUID()
 
-    @OneToMany(mappedBy = "workbook")
+    @OneToMany(mappedBy = "workbook", cascade = [(CascadeType.REMOVE)])
     @OrderBy("sequence asc")
     val questionSet: List<QuestionSet>? = null
 
@@ -43,6 +47,4 @@ data class Workbook(
     @LastModifiedDate
     var modifiedAt: LocalDateTime? = null
 
-
-    fun isDeleted():Boolean = this.deletedAt != null
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -1,10 +1,8 @@
 package com.swm_standard.phote.service
 
-import com.swm_standard.phote.common.exception.AlreadyDeletedException
 import com.swm_standard.phote.common.exception.NotFoundException
 import com.swm_standard.phote.dto.CreateWorkbookResponse
 import com.swm_standard.phote.dto.DeleteWorkbookResponse
-import com.swm_standard.phote.dto.QuestionSetDto
 import com.swm_standard.phote.dto.ReadWorkbookDetailResponse
 import com.swm_standard.phote.entity.Workbook
 import com.swm_standard.phote.repository.MemberRepository
@@ -31,27 +29,16 @@ class WorkbookService(
 
     @Transactional
     fun deleteWorkbook(id: UUID): DeleteWorkbookResponse {
-        val workbook = workbookRepository.findById(id).orElseThrow { NotFoundException("존재하지 않는 workbook") }
-        if (workbook.isDeleted()) throw AlreadyDeletedException("workbook")
 
-        workbook.deletedAt = LocalDateTime.now()
-        val deletedWorkbook = workbookRepository.save(workbook)
+        workbookRepository.deleteById(id)
 
-        return DeleteWorkbookResponse(deletedWorkbook.id, deletedWorkbook.deletedAt!!)
+        return DeleteWorkbookResponse(id, LocalDateTime.now())
     }
 
     fun readWorkbookDetail(id: UUID) : ReadWorkbookDetailResponse {
-        val workbook = workbookRepository.findById(id).orElseThrow { NotFoundException(message = "존재하지 않는 workbook") }
-        if (workbook.isDeleted()) throw AlreadyDeletedException("workbook")
+        val workbook = workbookRepository.findById(id).orElseThrow { NotFoundException() }
 
         val questionSet = questionSetRepository.findAllByWorkbookId(id)
-
-        val questionSetDto: List<QuestionSetDto> = questionSet.filter { !it.isDeleted() }.map { set ->
-            QuestionSetDto(
-                set.sequence,
-                set.question
-            )
-        }
 
         return ReadWorkbookDetailResponse(
             workbook.id,
@@ -60,7 +47,7 @@ class WorkbookService(
             workbook.emoji!!,
             workbook.createdAt,
             workbook.modifiedAt,
-            questionSetDto
+            questionSet
             )
     }
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- `Workbook` 삭제 시에 연관된 `QuestionSet` 도 삭제되도록 함
- 삭제 부분 전반적으로 리팩토링을 진행함
- 엔티티 내의 delete 관련 메서드를 삭제하고 `@ SQLRestriction` 과 `@ SQLDelete` 를 사용하여 일반적인 삭제처럼 사용할 수 있도록 함
- `Workbook` 의 `questionSet` 필드에 `Cascade.REMOVE` 를  적용함

---


### ✨ 참고 사항

x 

---

### ⏰ 현재 버그

x 

---

### ✏ Git Close #50