### PR TITLE
Fix: exception에서 fieldName표시하도록 Refactor

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
@@ -66,7 +66,8 @@ class CustomExceptionHandler {
 
     @ExceptionHandler(NotFoundException::class)
     protected fun notFoundException(ex: NotFoundException) : ResponseEntity<BaseResponse<Map<String, String>>> {
-        return ResponseEntity(BaseResponse(ErrorCode.NOT_FOUND.name, ErrorCode.NOT_FOUND.statusCode, ex.message ?: ErrorCode.NOT_FOUND.msg), HttpStatus.NOT_FOUND)
+        val errors = mapOf(ex.fieldName to (ex.message ?: "Not Exception Message"))
+        return ResponseEntity(BaseResponse(ErrorCode.NOT_FOUND.name, ErrorCode.NOT_FOUND.statusCode, ex.message ?: ErrorCode.NOT_FOUND.msg, errors), HttpStatus.NOT_FOUND)
 
     }
 

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -20,7 +20,7 @@ class QuestionService (
     private val questionSetRepository: QuestionSetRepository) {
     @Transactional
     fun readQuestionDetail(id: UUID): ReadQuestionDetailResponseDto {
-        val question = questionRepository.findById(id).orElseThrow { NotFoundException("존재하지 않는 UUID") }
+        val question = questionRepository.findById(id).orElseThrow { NotFoundException("questionId","존재하지 않는 UUID") }
 
         // options가 있는 객관식일 경우
         if (question.options != null) {
@@ -37,7 +37,7 @@ class QuestionService (
 
     @Transactional
     fun deleteQuestion(id: UUID): DeleteQuestionResponseDto {
-        val question = questionRepository.findById(id).orElseThrow { NotFoundException("존재하지 않는 UUID") }
+        val question = questionRepository.findById(id).orElseThrow { NotFoundException("questionId","존재하지 않는 UUID") }
 
         val now = LocalDateTime.now()
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 현재 BadRequestException, NotFoundException에서 위와 같이 fieldName을 사용하고 있지 않은데, 어떤 곳에서 에러가 났는지 data객체에 싸서 fieldName표시하도록 refactor
---

### ✨ 참고 사항
![image](https://github.com/swm-standard/Phote_BE/assets/87180069/6457fdb3-daa7-4726-a67a-3bbfee65fddc)
- 위와 같이 반환
---

### ⏰ 현재 버그

---

### ✏ Git Close #52 