### PR TITLE
Fix: deleteQuestion 로직 Refactor + Question 엔티티 수정

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.*
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import org.hibernate.type.SqlTypes
 import org.springframework.data.annotation.LastModifiedDate
@@ -12,6 +13,7 @@ import java.util.*
 
 
 @Entity
+@SQLDelete(sql = "UPDATE question SET deleted_at = NOW() WHERE question_uuid = ?")
 @SQLRestriction("deleted_at is NULL")
 data class Question(
 
@@ -19,7 +21,7 @@ data class Question(
     val id: UUID = UUID.randomUUID(),
 
 
-    @ManyToOne(cascade = [(CascadeType.REMOVE)])
+    @ManyToOne
     @JoinColumn(name = "member_id")
     @JsonIgnore
     val member: Member,
@@ -37,13 +39,12 @@ data class Question(
 
     val category: String,
 
-    @OneToMany(mappedBy = "question")
+    @OneToMany(mappedBy = "question", cascade = [CascadeType.REMOVE])
     @JsonIgnore
-    val questionSet: Set<QuestionSet>?,
+    val questionSet: List<QuestionSet>? = null,
 
-    @JoinColumn(name = "tag_id", nullable = true)
-    @OneToMany
-    val tags: List<Tag>,
+    @OneToMany(mappedBy = "question", cascade = [CascadeType.REMOVE])
+    val tags: List<Tag>? = null,
 
     val memo: String?,
 

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -37,20 +37,12 @@ class QuestionService (
 
     @Transactional
     fun deleteQuestion(id: UUID): DeleteQuestionResponseDto {
-        val question = questionRepository.findById(id).orElseThrow { NotFoundException("questionId","존재하지 않는 UUID") }
 
-        val now = LocalDateTime.now()
+        // 존재하지 않는 question id가 아닌지 확인
+        questionRepository.findById(id).orElseThrow { NotFoundException("questionId","존재하지 않는 UUID") }
 
-        // workbook과의 관계 끊어주기
-        questionSetRepository.markDeletedByQuestionId(id, now)
+        questionRepository.deleteById(id)
 
-        // deletedAt필드 채우기
-        question.apply {
-            deletedAt = now
-        }.also {
-            questionRepository.save(it)
-        }
-
-        return DeleteQuestionResponseDto(id, question.deletedAt!!)
+        return DeleteQuestionResponseDto(id, LocalDateTime.now())
     }
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 문제가 삭제될 때 Tag와 QuestionSet도 같이 삭제되도록 cascade달아줬습니다.
- Question 엔티티 속에서 member참조에 대한 cascade를 삭제했습니다. 기존은 문제가 삭제될 때 멤버도 같이 삭제되는 로직이라 수정했습니다.
- Question 엔티티 속의 Tag를 nullble 하게 변경했습니다.
---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close #54 