### PR TITLE
Feat: readWorkbookList (Seyeon/swm 57)

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
@@ -1,10 +1,8 @@
 package com.swm_standard.phote.controller
 
+import com.swm_standard.phote.common.resolver.memberId.MemberId
 import com.swm_standard.phote.common.responsebody.BaseResponse
-import com.swm_standard.phote.dto.DeleteWorkbookResponse
-import com.swm_standard.phote.dto.CreateWorkbookRequest
-import com.swm_standard.phote.dto.CreateWorkbookResponse
-import com.swm_standard.phote.dto.ReadWorkbookDetailResponse
+import com.swm_standard.phote.dto.*
 import com.swm_standard.phote.service.WorkbookService
 import jakarta.validation.Valid
 import org.springframework.security.core.Authentication
@@ -42,5 +40,13 @@ class WorkbookController(private val workbookService: WorkbookService) {
         val workbookDetail = workbookService.readWorkbookDetail(workbookId)
 
         return BaseResponse(msg = "문제집 정보 읽기 성공", data = workbookDetail)
+    }
+
+    @GetMapping("/workbooks")
+    fun readWorkbookList(@MemberId memberId: UUID): BaseResponse<List<ReadWorkbookListResponse>> {
+
+        val readWorkbookList = workbookService.readWorkbookList(memberId)
+
+        return BaseResponse(msg = "문제집 목록 조회 성공", data = readWorkbookList)
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -61,6 +61,6 @@ data class ReadWorkbookListResponse(
 
     val quantity: Int,
 
-    val createdAt: LocalDateTime,
+    val modifiedAt: LocalDateTime?
 
 )

--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -49,3 +49,18 @@ data class ReadWorkbookDetailResponse(
 
     val questions: List<QuestionSet>,
 )
+
+data class ReadWorkbookListResponse(
+    val id: UUID,
+
+    val title: String,
+
+    val description: String?,
+
+    val emoji: String,
+
+    val quantity: Int,
+
+    val createdAt: LocalDateTime,
+
+)

--- a/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
@@ -20,7 +20,7 @@ data class Workbook(
     @JsonIgnore
     val member: Member,
 
-    var emoji: String?,
+    var emoji: String,
 
 ){
 

--- a/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
@@ -41,7 +41,7 @@ data class Workbook(
     var deletedAt: LocalDateTime? = null
 
     @LastModifiedDate
-    var modifiedAt: LocalDateTime? = null
+    var modifiedAt: LocalDateTime? = LocalDateTime.now()
 
     fun isDeleted():Boolean = this.deletedAt != null
 }

--- a/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
@@ -32,7 +32,7 @@ data class Workbook(
     val questionSet: List<QuestionSet>? = null
 
     @ColumnDefault(value = "0")
-    var quantity: Int? = null
+    var quantity: Int = 0
 
     @CreationTimestamp
     val createdAt: LocalDateTime = LocalDateTime.now()
@@ -42,7 +42,6 @@ data class Workbook(
 
     @LastModifiedDate
     var modifiedAt: LocalDateTime? = null
-
 
     fun isDeleted():Boolean = this.deletedAt != null
 }

--- a/src/main/kotlin/com/swm_standard/phote/repository/WorkbookRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/WorkbookRepository.kt
@@ -1,8 +1,11 @@
 package com.swm_standard.phote.repository
 
+import com.swm_standard.phote.entity.Member
 import com.swm_standard.phote.entity.Workbook
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.*
 
 interface WorkbookRepository: JpaRepository<Workbook, UUID> {
+
+    fun findAllByMember(member: Member): List<Workbook>
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -71,7 +71,7 @@ class WorkbookService(
                 workbook.description,
                 workbook.emoji,
                 workbook.quantity,
-                workbook.createdAt,
+                workbook.modifiedAt,
             )
         }
     }

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -1,11 +1,11 @@
 package com.swm_standard.phote.service
 
+import com.swm_standard.phote.common.exception.InvalidInputException
 import com.swm_standard.phote.common.exception.NotFoundException
 import com.swm_standard.phote.dto.CreateWorkbookResponse
 import com.swm_standard.phote.dto.DeleteWorkbookResponse
 import com.swm_standard.phote.dto.ReadWorkbookDetailResponse
 import com.swm_standard.phote.dto.ReadWorkbookListResponse
-import com.swm_standard.phote.entity.Member
 import com.swm_standard.phote.entity.Workbook
 import com.swm_standard.phote.repository.MemberRepository
 import com.swm_standard.phote.repository.QuestionSetRepository
@@ -55,10 +55,10 @@ class WorkbookService(
     }
 
     fun readWorkbookList(memberId: UUID) : List<ReadWorkbookListResponse> {
-        val member: Member = memberRepository.findById(memberId).orElseThrow { InvalidInputException("memberId") }
+        val member = memberRepository.findById(memberId).orElseThrow { InvalidInputException("memberId") }
         val workbooks: List<Workbook> = workbookRepository.findAllByMember(member)
 
-        return workbooks.filter { !it.isDeleted() }.map { workbook ->
+        return workbooks.map { workbook ->
             ReadWorkbookListResponse(
                 workbook.id,
                 workbook.title,

--- a/src/test/kotlin/com/swm_standard/phote/entity/WorkbookTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/WorkbookTest.kt
@@ -19,7 +19,7 @@ class WorkbookTest {
                 provider = Provider.APPLE,
                 joinedAt = LocalDateTime.now(),
                 deletedAt = null
-            ), emoji = null
+            ), emoji = "😀"
         )
         workbook.deletedAt = LocalDateTime.now()
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 사용자가 생성한 문제집 목록을 조회하는 기능을 구현함

#### 🙏 응답 예시 🙏
![스크린샷 2024-07-11 오후 4 02 59](https://github.com/swm-standard/Phote_BE/assets/90397541/5b3a86de-be31-4038-a8ea-ef678a8eff5c)



---

### ✨ 참고 사항

- authentication의 사용자 정보를 이용하므로 사용자 관련 에러는 jwt 인가 에러 처리로 함께 다뤄야할 것 같음
- `createdAt` 대신 `modifiedAt` 만 담았으며 이에 따라 workbook 생성 시에도 `createdAt` 과 같이 현재 시각이 바로 선언되도록 변경함

---

### ⏰ 현재 버그

x

---

### ✏ Git Close #37 