### PR TITLE
Feat: CreateQuestion 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation:3.3.0")
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+	implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
 
 }
 

--- a/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
@@ -4,6 +4,7 @@ import com.swm_standard.phote.common.responsebody.BaseResponse
 import com.swm_standard.phote.common.responsebody.ErrorCode
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -75,6 +76,14 @@ class CustomExceptionHandler {
     protected fun methodArgumentTypeMismatchException(ex: MethodArgumentTypeMismatchException) : ResponseEntity<BaseResponse<Map<String, String>>> {
 
         val errors = mapOf(ex.name to (ex.message ?: "Not Exception Message"))
+        return ResponseEntity(BaseResponse(ErrorCode.BAD_REQUEST.name, ErrorCode.BAD_REQUEST.statusCode, ErrorCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
+
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    protected fun httpMessageNotReadableException(ex: HttpMessageNotReadableException) : ResponseEntity<BaseResponse<Map<String, String>>> {
+
+        val errors = mapOf("" to (ex.message ?: "Not Exception Message"))
         return ResponseEntity(BaseResponse(ErrorCode.BAD_REQUEST.name, ErrorCode.BAD_REQUEST.statusCode, ErrorCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
 
     }

--- a/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
@@ -9,7 +9,6 @@ import com.swm_standard.phote.dto.ReadQuestionDetailResponseDto
 import com.swm_standard.phote.external.aws.S3Service
 import com.swm_standard.phote.service.QuestionService
 import jakarta.validation.Valid
-import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import java.util.*

--- a/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
@@ -1,22 +1,35 @@
 package com.swm_standard.phote.controller
 
+import com.swm_standard.phote.common.resolver.memberId.MemberId
 import com.swm_standard.phote.common.responsebody.BaseResponse
+import com.swm_standard.phote.dto.CreateQuestionRequestDto
+import com.swm_standard.phote.dto.CreateQuestionResponseDto
 import com.swm_standard.phote.dto.DeleteQuestionResponseDto
 import com.swm_standard.phote.dto.ReadQuestionDetailResponseDto
+import com.swm_standard.phote.external.aws.S3Service
 import com.swm_standard.phote.service.QuestionService
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import jakarta.validation.Valid
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
 import java.util.*
 
 @RestController
 @RequestMapping("/api")
-class QuestionController {
-    @Autowired
-    private lateinit var questionService: QuestionService
+class QuestionController(
+    private val questionService: QuestionService,
+    private val s3Service: S3Service
+) {
+
+    @PostMapping( "/question")
+    fun createQuestion(@MemberId memberId: UUID,
+                       @Valid @RequestPart request: CreateQuestionRequestDto,
+                       @RequestPart image: MultipartFile?
+    ): BaseResponse<CreateQuestionResponseDto> {
+        val imageUrl = image?.let { s3Service.uploadImage(it) }
+        println(imageUrl)
+        return BaseResponse(msg = "문제 생성 성공", data = questionService.createQuestion(memberId, request, imageUrl))
+    }
 
     @GetMapping("/question/{id}")
     fun readQuestionDetail(@PathVariable(

--- a/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
@@ -26,7 +26,6 @@ class QuestionController(
                        @RequestPart image: MultipartFile?
     ): BaseResponse<CreateQuestionResponseDto> {
         val imageUrl = image?.let { s3Service.uploadImage(it) }
-        println(imageUrl)
         return BaseResponse(msg = "문제 생성 성공", data = questionService.createQuestion(memberId, request, imageUrl))
     }
 

--- a/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
@@ -2,8 +2,8 @@ package com.swm_standard.phote.dto
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.swm_standard.phote.entity.Question
+import com.swm_standard.phote.entity.Tag
 import jakarta.validation.constraints.NotBlank
-import org.springframework.web.multipart.MultipartFile
 import java.time.LocalDateTime
 import java.util.*
 

--- a/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
@@ -45,12 +45,12 @@ class DeleteQuestionResponseDto (
 )
 
 data class CreateQuestionRequestDto(
-    @NotBlank(message = "statement 미입력")
+    @field:NotBlank(message = "statement 미입력")
     val statement: String,
-    @NotBlank(message = "category 미입력")
+    @field:NotBlank(message = "category 미입력")
     val category: String,
     val options: JsonNode? = null,
-    @NotBlank(message = "answer 미입력")
+    @field:NotBlank(message = "answer 미입력")
     val answer: String,
     val tags: List<String>? = null,
     val memo: String? = null

--- a/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
@@ -2,6 +2,8 @@ package com.swm_standard.phote.dto
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.swm_standard.phote.entity.Question
+import jakarta.validation.constraints.NotBlank
+import org.springframework.web.multipart.MultipartFile
 import java.time.LocalDateTime
 import java.util.*
 
@@ -40,4 +42,20 @@ data class ReadQuestionDetailResponseDto(
 class DeleteQuestionResponseDto (
     val id: UUID,
     val deletedAt: LocalDateTime
+)
+
+data class CreateQuestionRequestDto(
+    @NotBlank(message = "statement 미입력")
+    val statement: String,
+    @NotBlank(message = "category 미입력")
+    val category: String,
+    val options: JsonNode? = null,
+    @NotBlank(message = "answer 미입력")
+    val answer: String,
+    val tags: List<String>? = null,
+    val memo: String? = null
+)
+
+data class CreateQuestionResponseDto(
+    val id: UUID
 )

--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -56,6 +56,6 @@ data class Question(
     var deletedAt: LocalDateTime? = null,
 
     @LastModifiedDate
-    var modifiedAt: LocalDateTime? = null
+    var modifiedAt: LocalDateTime? = LocalDateTime.now()
 
     )

--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.*
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import org.hibernate.type.SqlTypes
 import org.springframework.data.annotation.LastModifiedDate
@@ -12,6 +13,7 @@ import java.util.*
 
 
 @Entity
+@SQLDelete(sql = "UPDATE question SET deleted_at = NOW() WHERE question_uuid = ?")
 @SQLRestriction("deleted_at is NULL")
 data class Question(
 
@@ -37,13 +39,12 @@ data class Question(
 
     val category: String,
 
-    @OneToMany(mappedBy = "question")
+    @OneToMany(mappedBy = "question", cascade = [CascadeType.REMOVE])
     @JsonIgnore
-    val questionSet: Set<QuestionSet>?,
+    val questionSet: Set<QuestionSet>? = null,
 
-    @JoinColumn(name = "tag_id", nullable = true)
-    @OneToMany
-    val tags: List<Tag>,
+    @OneToMany(mappedBy = "question", cascade = [CascadeType.REMOVE])
+    var tags: MutableList<Tag> = mutableListOf(),
 
     val memo: String?,
 
@@ -51,9 +52,9 @@ data class Question(
     val createdAt: LocalDateTime = LocalDateTime.now(),
 
     @JsonIgnore
-    var deletedAt: LocalDateTime?,
+    var deletedAt: LocalDateTime? = null,
 
     @LastModifiedDate
-    var modifiedAt: LocalDateTime?,
+    var modifiedAt: LocalDateTime? = null
 
     )

--- a/src/main/kotlin/com/swm_standard/phote/entity/Tag.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Tag.kt
@@ -1,13 +1,18 @@
 package com.swm_standard.phote.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.*
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
 import java.time.LocalDateTime
 
 @Entity
+@SQLDelete(sql = "UPDATE tag SET deleted_at = NOW() WHERE tag_id = ?")
+@SQLRestriction("deleted_at is NULL")
 data class Tag(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "tag_id")
-    val id: Long,
+    val id: Long = 0,
 
     @Column(unique = true)
     val name: String,
@@ -16,5 +21,6 @@ data class Tag(
     @ManyToOne
     val question: Question,
 
-    val deletedAt: LocalDateTime?
+    @JsonIgnore
+    val deletedAt: LocalDateTime? = null
 )

--- a/src/main/kotlin/com/swm_standard/phote/entity/Tag.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Tag.kt
@@ -11,16 +11,15 @@ import java.time.LocalDateTime
 @SQLRestriction("deleted_at is NULL")
 data class Tag(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "tag_id")
+    @Column(name = "tag_id", unique = true)
     val id: Long = 0L,
 
-    @Column(unique = true)
     val name: String,
 
     @JoinColumn(name = "question_id")
     @ManyToOne
     @JsonIgnore
-    val question: Question,
+    var question: Question,
 
     @JsonIgnore
     val deletedAt: LocalDateTime? = null

--- a/src/main/kotlin/com/swm_standard/phote/entity/Tag.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Tag.kt
@@ -12,7 +12,7 @@ import java.time.LocalDateTime
 data class Tag(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "tag_id")
-    val id: Long = 0,
+    val id: Long = 0L,
 
     @Column(unique = true)
     val name: String,

--- a/src/main/kotlin/com/swm_standard/phote/external/aws/S3Config.kt
+++ b/src/main/kotlin/com/swm_standard/phote/external/aws/S3Config.kt
@@ -1,0 +1,31 @@
+package com.swm_standard.phote.external.aws
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+@Configuration
+class S3Config(
+    @Value("\${cloud.aws.credentials.accessKey}")
+    val accessKey: String,
+    @Value("\${cloud.aws.credentials.secretKey}")
+    val secretKey: String,
+    @Value("\${cloud.aws.region.static}")
+    val region: String
+) {
+    @Bean
+    fun amazonS3Client(): AmazonS3Client {
+        val credentials = BasicAWSCredentials(accessKey, secretKey)
+
+        return AmazonS3ClientBuilder
+            .standard()
+            .withRegion(region)
+            .withCredentials(AWSStaticCredentialsProvider(credentials))
+            .build() as AmazonS3Client
+    }
+}

--- a/src/main/kotlin/com/swm_standard/phote/external/aws/S3Service.kt
+++ b/src/main/kotlin/com/swm_standard/phote/external/aws/S3Service.kt
@@ -1,0 +1,67 @@
+package com.swm_standard.phote.external.aws
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.swm_standard.phote.common.exception.BadRequestException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.multipart.MultipartFile
+import java.util.*
+
+@Component
+class S3Service(
+    @Value("\${cloud.aws.s3.bucketName}")
+    private val bucket: String,
+    private val amazonS3: AmazonS3,
+) {
+    companion object {
+        const val TYPE_IMAGE = "image"
+    }
+    fun uploadImage(multipartFile: MultipartFile): String {
+        val originalFilename = multipartFile.originalFilename
+            ?: throw BadRequestException("image 미입력")
+        FileValidate.checkImageFormat(originalFilename)
+        val fileName = "${UUID.randomUUID()}-${originalFilename}"
+        val objectMetadata = setFileDateOption(
+            type = TYPE_IMAGE,
+            file = getFileExtension(originalFilename),
+            multipartFile = multipartFile
+        )
+        amazonS3.putObject(bucket, fileName, multipartFile.inputStream, objectMetadata)
+        val imageUrl = amazonS3.getUrl(bucket,fileName).toString()
+        return imageUrl
+    }
+
+    private fun getFileExtension(fileName: String): String {
+        val extensionIndex = fileName.lastIndexOf('.')
+        return fileName.substring(extensionIndex + 1)
+    }
+
+    private fun setFileDateOption(
+        type: String,
+        file: String,
+        multipartFile: MultipartFile
+    ): ObjectMetadata {
+        val objectMetadata = ObjectMetadata()
+        objectMetadata.contentType = "/${type}/${getFileExtension(file)}"
+        objectMetadata.contentLength = multipartFile.inputStream.available().toLong()
+        return objectMetadata
+    }
+}
+
+class FileValidate {
+
+    companion object {
+        private val IMAGE_EXTENSIONS: List<String> = listOf("jpg", "png", "gif", "webp")
+        fun checkImageFormat(fileName: String) {
+            val extensionIndex = fileName.lastIndexOf('.')
+            if(extensionIndex == -1) {
+                throw BadRequestException("파일 확장자가 없음")
+            }
+            val extension = fileName.substring(extensionIndex + 1)
+            require(IMAGE_EXTENSIONS.contains(extension)) {
+                throw BadRequestException("지원하지 않는 파일 확장자")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/swm_standard/phote/repository/TagRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/TagRepository.kt
@@ -1,0 +1,7 @@
+package com.swm_standard.phote.repository
+
+import com.swm_standard.phote.entity.Tag
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TagRepository: JpaRepository<Tag, Long> {
+}

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -2,22 +2,62 @@ package com.swm_standard.phote.service
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.swm_standard.phote.common.exception.AlreadyDeletedException
-import com.swm_standard.phote.common.exception.BadRequestException
 import com.swm_standard.phote.common.exception.NotFoundException
+import com.swm_standard.phote.dto.CreateQuestionRequestDto
+import com.swm_standard.phote.dto.CreateQuestionResponseDto
 import com.swm_standard.phote.dto.DeleteQuestionResponseDto
 import com.swm_standard.phote.dto.ReadQuestionDetailResponseDto
+import com.swm_standard.phote.entity.Question
+import com.swm_standard.phote.entity.Tag
+import com.swm_standard.phote.repository.MemberRepository
 import com.swm_standard.phote.repository.QuestionRepository
 import com.swm_standard.phote.repository.QuestionSetRepository
+import com.swm_standard.phote.repository.TagRepository
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.UUID
 
 @Service
-class QuestionService (
+class QuestionService(
     private val questionRepository: QuestionRepository,
-    private val questionSetRepository: QuestionSetRepository) {
+    private val questionSetRepository: QuestionSetRepository,
+    private val memberRepository: MemberRepository,
+    private val tagRepository: TagRepository
+) {
+    @Transactional
+    fun createQuestion(memberId:UUID, request: CreateQuestionRequestDto, imageUrl: String?)
+    : CreateQuestionResponseDto {
+
+        // 문제 생성 유저 확인
+        val member = memberRepository.findById(memberId).orElseThrow { NotFoundException("존재하지 않는 member") }
+
+        // options를 JSON -> 문자열로 변환
+        val options = request.options?.let {
+            ObjectMapper().writeValueAsString(it)
+        }
+
+        // 문제 저장
+        val question = questionRepository.save(
+            Question(
+                member = member,
+                statement = request.statement,
+                image = imageUrl,
+                category = request.category,
+                options = options,
+                answer = request.answer,
+                memo = request.memo
+            )
+        )
+
+        // 태그 생성
+        request.tags?.forEach {
+            tagRepository.save(Tag(name = it, question = question))
+        }
+
+        return CreateQuestionResponseDto(question.id)
+    }
+
     @Transactional
     fun readQuestionDetail(id: UUID): ReadQuestionDetailResponseDto {
         val question = questionRepository.findById(id).orElseThrow { NotFoundException("questionId","존재하지 않는 UUID") }

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -21,7 +21,6 @@ import java.util.UUID
 @Service
 class QuestionService(
     private val questionRepository: QuestionRepository,
-    private val questionSetRepository: QuestionSetRepository,
     private val memberRepository: MemberRepository,
     private val tagRepository: TagRepository
 ) {

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -1,7 +1,5 @@
 package com.swm_standard.phote.service
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.swm_standard.phote.common.exception.NotFoundException
 import com.swm_standard.phote.dto.CreateQuestionRequestDto
 import com.swm_standard.phote.dto.CreateQuestionResponseDto
@@ -30,11 +28,6 @@ class QuestionService(
         // 문제 생성 유저 확인
         val member = memberRepository.findById(memberId).orElseThrow { NotFoundException("존재하지 않는 member") }
 
-        // options를 JSON -> 문자열로 변환
-        val options = request.options?.let {
-            ObjectMapper().writeValueAsString(it)
-        }
-
         // 문제 저장
         val question = questionRepository.save(
             Question(
@@ -42,7 +35,7 @@ class QuestionService(
                 statement = request.statement,
                 image = imageUrl,
                 category = request.category,
-                options = options,
+                options = request.options,
                 answer = request.answer,
                 memo = request.memo
             )


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 기본적인 로직은 문제를 생성하려고 할 때, 
생성하려는 유저 확인 -> 문제 생성(저장) -> 태그 생성(저장) 입니다.

---

### ✨ 참고 사항
- ~~statement나 answer등 필수적인 필드가 request로 들어오지 않았을 때 exception handling을 어케해야할지.... 도와줘....................으악~~
- Tag 엔티티의 name 속성에서 unique를 제외했습니다. id에는 unique가 빠져있길래 추가
- 나중에 또 꺼내볼 일이 있을까하여(없을듯) s3 이미지 업로드 로직 한줄 요약(/external/aws/S3service.kt 파일 참조)
  - 멀티파트폼으로 이미지가 들어오면 올바른 확장자("jpg", "png", "gif", "webp")인지 확인하고 -> 이미지 파일 이름 생성해서 S3에 올린 후 이미지 url 반환
---

### ⏰ 현재 버그
---

### ✏ Git Close #43 