### PR TITLE
Fix: readQuestionDetail api response에 tag추가 & options타입 변경에 따른 조회 로직 수정

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
@@ -15,22 +15,13 @@ data class ReadQuestionDetailResponseDto(
     val category: String,
     val memo: String? = null
 ) {
-    constructor(question: Question, options: JsonNode) : this(
-        createdAt = question.createdAt,
-        modifiedAt = question.modifiedAt,
-        statement = question.statement,
-        image = question.image,
-        options = options,
-        answer = question.answer,
-        category = question.category,
-        memo = question.memo
-    )
 
     constructor(question: Question) : this(
         createdAt = question.createdAt,
         modifiedAt = question.modifiedAt,
         statement = question.statement,
         image = question.image,
+        options = question.options,
         answer = question.answer,
         category = question.category,
         memo = question.memo

--- a/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
@@ -2,6 +2,7 @@ package com.swm_standard.phote.dto
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.swm_standard.phote.entity.Question
+import com.swm_standard.phote.entity.Tag
 import java.time.LocalDateTime
 import java.util.*
 
@@ -13,16 +14,18 @@ data class ReadQuestionDetailResponseDto(
     val options: JsonNode? = null,
     val answer: String,
     val category: String,
+    val tags: List<Tag>? = null,
     val memo: String? = null
 ) {
 
-    constructor(question: Question) : this(
+    constructor(question: Question, tags: List<Tag>?) : this(
         createdAt = question.createdAt,
         modifiedAt = question.modifiedAt,
         statement = question.statement,
         image = question.image,
         options = question.options,
         answer = question.answer,
+        tags = tags,
         category = question.category,
         memo = question.memo
     )

--- a/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
@@ -18,14 +18,14 @@ data class ReadQuestionDetailResponseDto(
     val memo: String? = null
 ) {
 
-    constructor(question: Question, tags: List<Tag>?) : this(
+    constructor(question: Question) : this(
         createdAt = question.createdAt,
         modifiedAt = question.modifiedAt,
         statement = question.statement,
         image = question.image,
         options = question.options,
         answer = question.answer,
-        tags = tags,
+        tags = question.tags,
         category = question.category,
         memo = question.memo
     )

--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -45,7 +45,7 @@ data class Question(
     val questionSet: List<QuestionSet>? = null,
 
     @OneToMany(mappedBy = "question", cascade = [CascadeType.REMOVE])
-    val tags: List<Tag>? = null,
+    var tags: MutableList<Tag> = mutableListOf(),
 
     val memo: String?,
 

--- a/src/main/kotlin/com/swm_standard/phote/repository/TagRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/TagRepository.kt
@@ -1,0 +1,9 @@
+package com.swm_standard.phote.repository
+
+import com.swm_standard.phote.entity.Tag
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface TagRepository: JpaRepository<Tag, Long> {
+    fun findAllByQuestionId(questionId: UUID): List<Tag>?
+}

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -22,15 +22,6 @@ class QuestionService (
     fun readQuestionDetail(id: UUID): ReadQuestionDetailResponseDto {
         val question = questionRepository.findById(id).orElseThrow { NotFoundException("questionId","존재하지 않는 UUID") }
 
-        // options가 있는 객관식일 경우
-        if (question.options != null) {
-            // string type으로 오는 options를 deserialize
-            val objectMapper = ObjectMapper()
-            val questionOptionsObject: JsonNode = objectMapper.readTree(question.options)
-
-            return ReadQuestionDetailResponseDto(question, questionOptionsObject)
-        }
-
         // options가 없는 주관식일 경우
         return ReadQuestionDetailResponseDto(question)
     }

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -4,7 +4,6 @@ import com.swm_standard.phote.common.exception.NotFoundException
 import com.swm_standard.phote.dto.DeleteQuestionResponseDto
 import com.swm_standard.phote.dto.ReadQuestionDetailResponseDto
 import com.swm_standard.phote.repository.QuestionRepository
-import com.swm_standard.phote.repository.QuestionSetRepository
 import com.swm_standard.phote.repository.TagRepository
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
@@ -19,9 +18,8 @@ class QuestionService(
     @Transactional
     fun readQuestionDetail(id: UUID): ReadQuestionDetailResponseDto {
         val question = questionRepository.findById(id).orElseThrow { NotFoundException("questionId","존재하지 않는 UUID") }
-        val tags = tagRepository.findAllByQuestionId(question.id)
 
-        return ReadQuestionDetailResponseDto(question, tags)
+        return ReadQuestionDetailResponseDto(question)
     }
 
     @Transactional

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -1,29 +1,27 @@
 package com.swm_standard.phote.service
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.swm_standard.phote.common.exception.AlreadyDeletedException
-import com.swm_standard.phote.common.exception.BadRequestException
 import com.swm_standard.phote.common.exception.NotFoundException
 import com.swm_standard.phote.dto.DeleteQuestionResponseDto
 import com.swm_standard.phote.dto.ReadQuestionDetailResponseDto
 import com.swm_standard.phote.repository.QuestionRepository
 import com.swm_standard.phote.repository.QuestionSetRepository
+import com.swm_standard.phote.repository.TagRepository
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.UUID
 
 @Service
-class QuestionService (
+class QuestionService(
     private val questionRepository: QuestionRepository,
-    private val questionSetRepository: QuestionSetRepository) {
+    private val tagRepository: TagRepository
+) {
     @Transactional
     fun readQuestionDetail(id: UUID): ReadQuestionDetailResponseDto {
         val question = questionRepository.findById(id).orElseThrow { NotFoundException("questionId","존재하지 않는 UUID") }
+        val tags = tagRepository.findAllByQuestionId(question.id)
 
-        // options가 없는 주관식일 경우
-        return ReadQuestionDetailResponseDto(question)
+        return ReadQuestionDetailResponseDto(question, tags)
     }
 
     @Transactional


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- readQuestionDetail api의 response값에 Tag추가
- question의 options 타입이 JsonNode로 바뀌어 이에 따른 api 로직 수정
---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close #56 