### PR TITLE
Feat: addQuestionstoWorkbook

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/common/exception/AlreadyDeletedException.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/exception/AlreadyDeletedException.kt
@@ -1,6 +1,6 @@
 package com.swm_standard.phote.common.exception
 
-class AlreadyDeletedException (
+class AlreadyExistedException (
     val fieldName: String = "",
-    message: String = "이미 삭제된 리소스입니다."
+    message: String = "이미 존재하는 리소스입니다."
 ): RuntimeException(message)  

--- a/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
@@ -56,10 +56,10 @@ class CustomExceptionHandler {
         return ResponseEntity(BaseResponse(ErrorCode.ERROR.name, ErrorCode.BAD_REQUEST.statusCode, ErrorCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
     }
 
-    @ExceptionHandler(AlreadyDeletedException::class)
-    protected fun alreadyDeletedException(ex: AlreadyDeletedException) : ResponseEntity<BaseResponse<Map<String, String>>> {
+    @ExceptionHandler(AlreadyExistedException::class)
+    protected fun alreadyDeletedException(ex: AlreadyExistedException) : ResponseEntity<BaseResponse<Map<String, String>>> {
         val errors = mapOf(ex.fieldName to (ex.message ?: "Not Exception Message"))
-        return ResponseEntity(BaseResponse(ErrorCode.BAD_REQUEST.name, ErrorCode.BAD_REQUEST.statusCode, ErrorCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
+        return ResponseEntity(BaseResponse(ErrorCode.ERROR.name, ErrorCode.BAD_REQUEST.statusCode, ErrorCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
 
     }
 

--- a/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
@@ -52,7 +52,7 @@ class WorkbookController(private val workbookService: WorkbookService) {
     }
 
     @PostMapping("/workbook/{workbookId}")
-    fun addQuestionstoWorkbook(@PathVariable workbookId: UUID, @RequestBody @Valid request: AddQuestionstoWorbookRequest): BaseResponse<Unit> {
+    fun addQuestionstoWorkbook(@PathVariable workbookId: UUID, @RequestBody @Valid request: AddQuestionstoWorkbookRequest): BaseResponse<Unit> {
         if(request.questions.isEmpty()) throw InvalidInputException(fieldName = "questions", message = "question을 담아 요청해주세요.")
         workbookService.addQuestionstoWorkbook(workbookId,request)
 

--- a/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
@@ -1,5 +1,6 @@
 package com.swm_standard.phote.controller
 
+import com.swm_standard.phote.common.exception.InvalidInputException
 import com.swm_standard.phote.common.resolver.memberId.MemberId
 import com.swm_standard.phote.common.responsebody.BaseResponse
 import com.swm_standard.phote.dto.*
@@ -26,10 +27,10 @@ class WorkbookController(private val workbookService: WorkbookService) {
         return BaseResponse(msg = "문제집 생성 성공", data = workbook)
     }
 
-    @DeleteMapping("/workbook/{id}")
-    fun deleteWorkbook(@PathVariable("id") id: UUID): BaseResponse<DeleteWorkbookResponse> {
+    @DeleteMapping("/workbook/{workbookId}")
+    fun deleteWorkbook(@PathVariable workbookId: UUID): BaseResponse<DeleteWorkbookResponse> {
 
-        val deletedWorkbook = workbookService.deleteWorkbook(id)
+        val deletedWorkbook = workbookService.deleteWorkbook(workbookId)
 
         return BaseResponse(msg = "문제집 삭제 성공", data = deletedWorkbook)
     }
@@ -48,5 +49,14 @@ class WorkbookController(private val workbookService: WorkbookService) {
         val readWorkbookList = workbookService.readWorkbookList(memberId)
 
         return BaseResponse(msg = "문제집 목록 조회 성공", data = readWorkbookList)
+    }
+
+    @PostMapping("/workbook/{workbookId}")
+    fun addQuestionstoWorkbook(@PathVariable workbookId: UUID, @RequestBody @Valid request: AddQuestionstoWorbookRequest): BaseResponse<Unit> {
+        if(request.questions.isEmpty()) throw InvalidInputException(fieldName = "questions", message = "question을 담아 요청해주세요.")
+        workbookService.addQuestionstoWorkbook(workbookId,request)
+
+        return BaseResponse(msg = "문제집에 문제 추가 성공")
+
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -65,7 +65,7 @@ data class ReadWorkbookListResponse(
 
 )
 
-data class AddQuestionstoWorbookRequest(
+data class AddQuestionstoWorkbookRequest(
     @JsonProperty("questions")
     private val _questions: List<UUID>?
 ){

--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -64,3 +64,11 @@ data class ReadWorkbookListResponse(
     val modifiedAt: LocalDateTime?
 
 )
+
+data class AddQuestionstoWorbookRequest(
+    @JsonProperty("questions")
+    private val _questions: List<UUID>?
+){
+    val questions: List<UUID> get() = _questions!!
+
+}

--- a/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
@@ -11,9 +11,6 @@ import java.time.LocalDateTime
 @SQLDelete(sql = "UPDATE question_set SET deleted_at = NOW() WHERE question_set_id = ?")
 @SQLRestriction("deleted_at is NULL")
 data class QuestionSet(
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "questionSet_id")
-    val id: Long,
 
     @ManyToOne
     @JoinColumn(name = "question_id")
@@ -24,11 +21,19 @@ data class QuestionSet(
     @JsonIgnore
     val workbook: Workbook,
 
-    val sequence: Int,
+
+    ){
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "questionSet_id")
+    val id: Long = 0
+
+    var sequence: Int = 0
 
     @CreationTimestamp
-    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val createdAt: LocalDateTime = LocalDateTime.now()
 
     @JsonIgnore
-    var deletedAt: LocalDateTime?,
-    )
+    var deletedAt: LocalDateTime? = null
+
+}

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetRepository.kt
@@ -2,17 +2,12 @@ package com.swm_standard.phote.repository
 
 import com.swm_standard.phote.entity.QuestionSet
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
-import org.springframework.data.jpa.repository.Query
-import java.time.LocalDateTime
+
 import java.util.UUID
 
 interface QuestionSetRepository: JpaRepository<QuestionSet, UUID> {
 
     fun findAllByWorkbookId(workbookId:UUID): List<QuestionSet>
 
-    @Modifying
-    @Query("UPDATE QuestionSet qs SET qs.deletedAt = :deletedAt WHERE qs.question.id = :questionId")
-    fun markDeletedByQuestionId(questionId: UUID, deletedAt: LocalDateTime)
-
+    fun findByQuestionIdAndWorkbookId(questionId: UUID, workbookId: UUID): QuestionSet?
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -1,13 +1,14 @@
 package com.swm_standard.phote.service
 
+import com.swm_standard.phote.common.exception.AlreadyExistedException
 import com.swm_standard.phote.common.exception.InvalidInputException
 import com.swm_standard.phote.common.exception.NotFoundException
-import com.swm_standard.phote.dto.CreateWorkbookResponse
-import com.swm_standard.phote.dto.DeleteWorkbookResponse
-import com.swm_standard.phote.dto.ReadWorkbookDetailResponse
-import com.swm_standard.phote.dto.ReadWorkbookListResponse
+import com.swm_standard.phote.dto.*
+import com.swm_standard.phote.entity.Question
+import com.swm_standard.phote.entity.QuestionSet
 import com.swm_standard.phote.entity.Workbook
 import com.swm_standard.phote.repository.MemberRepository
+import com.swm_standard.phote.repository.QuestionRepository
 import com.swm_standard.phote.repository.QuestionSetRepository
 import com.swm_standard.phote.repository.WorkbookRepository
 import jakarta.transaction.Transactional
@@ -19,7 +20,8 @@ import java.util.UUID
 class WorkbookService(
     private val workbookRepository: WorkbookRepository,
     private val memberRepository: MemberRepository,
-    private val questionSetRepository: QuestionSetRepository
+    private val questionSetRepository: QuestionSetRepository,
+    private val questionRepository: QuestionRepository
 ) {
 
     @Transactional
@@ -69,6 +71,19 @@ class WorkbookService(
                 workbook.quantity,
                 workbook.modifiedAt,
             )
+        }
+    }
+
+    fun addQuestionstoWorkbook(workbookId: UUID, request: AddQuestionstoWorbookRequest) {
+
+        val workbook: Workbook = workbookRepository.findById(workbookId).orElseThrow { NotFoundException(fieldName = "workbook", message = "id 를 재확인해주세요.") }
+
+        request.questions.forEach { questionId ->
+            val question: Question = questionRepository.findById(questionId).orElseThrow { NotFoundException(fieldName = "question", message = "id 를 재확인해주세요.") }
+            questionSetRepository.findByQuestionIdAndWorkbookId(questionId, workbook.id)?.let { throw  AlreadyExistedException("questionId ($questionId)") }
+            QuestionSet(question, workbook).run {
+                questionSetRepository.save(this)
+            }
         }
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -74,7 +74,7 @@ class WorkbookService(
         }
     }
 
-    fun addQuestionstoWorkbook(workbookId: UUID, request: AddQuestionstoWorbookRequest) {
+    fun addQuestionstoWorkbook(workbookId: UUID, request: AddQuestionstoWorkbookRequest) {
 
         val workbook: Workbook = workbookRepository.findById(workbookId).orElseThrow { NotFoundException(fieldName = "workbook", message = "id 를 재확인해주세요.") }
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 특정 문제집에 여러 문제들을 추가하는 기능을 구현했습니다

**🙌🏻 응답 예시🙌🏻**
<img width= "400" alt="스크린샷 2024-07-12 오후 12 36 35" src="https://github.com/user-attachments/assets/aaa0661e-eee5-4f29-b4d9-6e5c4b724e00">

> 🙏 실패 케이스는 네가지나 돼서 필요 시 아래 포스트맨 링크 최하단 확인해주시면 될 것 같아요
   https://documenter.getpostman.com/view/30056543/2sA3e48TPn#4cff7b7f-b0a2-491d-b3fa-862410fc8095

- 사용하지 않는 `AlreadyDeletedException` 을 `AlreadyExistedException` 으로 변경하여 문제집 내에 이미 해당 문제가 존재하는 경우 핸들링하는데 사용했습니다.
@RinRinPARK `QuestionService` 에서 import 문에 `AlreadyDeletedException` 이 아직 남아있던 것 같던데 삭제하주시면 돼용

---

### ✨ 참고 사항

- 200 ResponseBody 에 data를 null 로 보내는데 담으면 좋을만한 필드가 있다면 알려주세요!
- `QuestionSetRepository` 의 사용하지 않는 `markDeletedByQuestionId` 는 삭제해뒀습니다! 확인 필수!!
- 읽기만 사용하는 메서드에서는 @ Transactional 을 readOnly로 사용하면 좋을 것 같은데 현재 사용 중인건 `jakarta.transaction.Transactional` 이라 시간이 날 때 스프링 Transactional로 바꿔볼까 합니다.
- 버그는 아니고 RequestBody 의 list가 비어있을 경우 컨트롤러에서 검증을 하고 있는데 custom validator 를 만들어서 dto에서 검사하는걸로 바꿀까 합니당

---

### ⏰ 현재 버그


x

---

### ✏ Git Close #38