### PR TITLE
Feat: SearchQuestions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,11 @@ plugins {
 	kotlin("plugin.jpa") version "1.9.24"
 	kotlin("jvm") version "1.9.24"
 	kotlin("plugin.spring") version "1.9.24"
+
+	//for querydsl
+	kotlin("kapt") version "1.7.10"
 }
+val queryDslVersion: String by extra
 
 group = "com.swm-standard"
 version = "0.0.1-SNAPSHOT"
@@ -42,6 +46,11 @@ dependencies {
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 	implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
 
+	//querydsl
+	implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+	kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
+	kapt("jakarta.annotation:jakarta.annotation-api")
+	kapt("jakarta.persistence:jakarta.persistence-api")
 }
 
 allOpen {
@@ -84,4 +93,23 @@ sentry {
 	org = "swm-standard"
 	projectName = "phote"
 	authToken = System.getenv("SENTRY_AUTH_TOKEN")
+}
+
+// Querydsl
+val generated = file("src/main/generated")
+tasks.withType<JavaCompile> {
+	options.generatedSourceOutputDirectory.set(generated)
+}
+sourceSets {
+	main {
+		kotlin.srcDirs += generated
+	}
+}
+tasks.named("clean") {
+	doLast {
+		generated.deleteRecursively()
+	}
+}
+kapt {
+	generateStubs = true
 }

--- a/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
@@ -8,7 +8,6 @@ import com.swm_standard.phote.external.aws.S3Service
 import com.swm_standard.phote.service.QuestionService
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.*
-import org.springframework.web.filter.RequestContextFilter
 import org.springframework.web.multipart.MultipartFile
 import java.util.*
 
@@ -16,8 +15,7 @@ import java.util.*
 @RequestMapping("/api")
 class QuestionController(
     private val questionService: QuestionService,
-    private val s3Service: S3Service,
-    private val requestContextFilter: RequestContextFilter
+    private val s3Service: S3Service
 ) {
 
     @PostMapping( "/question")

--- a/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
@@ -2,14 +2,13 @@ package com.swm_standard.phote.controller
 
 import com.swm_standard.phote.common.resolver.memberId.MemberId
 import com.swm_standard.phote.common.responsebody.BaseResponse
-import com.swm_standard.phote.dto.CreateQuestionRequestDto
-import com.swm_standard.phote.dto.CreateQuestionResponseDto
-import com.swm_standard.phote.dto.DeleteQuestionResponseDto
-import com.swm_standard.phote.dto.ReadQuestionDetailResponseDto
+import com.swm_standard.phote.dto.*
+import com.swm_standard.phote.entity.Question
 import com.swm_standard.phote.external.aws.S3Service
 import com.swm_standard.phote.service.QuestionService
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.filter.RequestContextFilter
 import org.springframework.web.multipart.MultipartFile
 import java.util.*
 
@@ -17,7 +16,8 @@ import java.util.*
 @RequestMapping("/api")
 class QuestionController(
     private val questionService: QuestionService,
-    private val s3Service: S3Service
+    private val s3Service: S3Service,
+    private val requestContextFilter: RequestContextFilter
 ) {
 
     @PostMapping( "/question")
@@ -37,9 +37,18 @@ class QuestionController(
         return BaseResponse(msg = "문제 상세조회 성공", data = questionService.readQuestionDetail(id))
     }
 
+    @GetMapping("/questions")
+    fun searchQuestions(@MemberId memberId: UUID,
+                        @RequestParam(required = false) tags: List<String>? = null,
+                        @RequestParam(required = false) keywords: List<String>? = null): BaseResponse<List<Question>> {
+        questionService.searchQuestions(memberId, tags, keywords)
+        return BaseResponse(msg = "문제 검색 성공", data=questionService.searchQuestions(memberId, tags, keywords))
+    }
+
     @DeleteMapping("/question/{id}")
     fun deleteQuestion(@PathVariable(required = true) id: UUID)
     : BaseResponse<DeleteQuestionResponseDto>{
         return BaseResponse(msg = "문제 삭제 성공", data = questionService.deleteQuestion(id))
     }
+
 }

--- a/src/main/kotlin/com/swm_standard/phote/external/querydsl/QueryDslConfig.kt
+++ b/src/main/kotlin/com/swm_standard/phote/external/querydsl/QueryDslConfig.kt
@@ -1,0 +1,19 @@
+package com.swm_standard.phote.external.querydsl
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+@Configuration
+class QueryDslConfig {
+    @PersistenceContext
+    lateinit var entityManager: EntityManager
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepository.kt
@@ -1,0 +1,8 @@
+package com.swm_standard.phote.repository
+
+import com.swm_standard.phote.entity.Question
+import java.util.*
+
+interface QuestionCustomRepository {
+    fun searchQuestionsList(memberId: UUID, tags: List<String>?, keywords: List<String>?): List<Question>
+}

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepositoryImpl.kt
@@ -1,0 +1,48 @@
+package com.swm_standard.phote.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.swm_standard.phote.entity.QQuestion
+import com.swm_standard.phote.entity.QTag
+import com.swm_standard.phote.entity.Question
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+class QuestionCustomRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+): QuestionCustomRepository{
+    override fun searchQuestionsList(memberId:UUID, tags: List<String>?, keywords: List<String>?): List<Question> {
+        val question = QQuestion.question
+        val tag = QTag.tag
+
+        val query = jpaQueryFactory
+            .selectFrom(question)
+            .where(question.member.id.eq(memberId))
+            .leftJoin(question.tags, tag)
+            .distinct()
+
+
+        // 태그 조건: tags로 들어온 태그들을 모두 포함하는 문제 검색
+        if (!tags.isNullOrEmpty()) {
+            val tagCondition = tags.map { tagName ->
+                jpaQueryFactory
+                    .selectFrom(tag)
+                    .where(tag.name.eq(tagName).and(tag.question.eq(question)))
+                    .exists()
+            }.reduce { sub, predicate -> sub.and(predicate) } // reduce: 서브쿼리(sub)들을 and조건으로 결합
+            query.where(tagCondition)
+        }
+
+        // 문항 조건: keywords로 들어온 검색어를 모두 포함하는 문항(statement)을 가진 문제 검색
+        if (!keywords.isNullOrEmpty()) {
+            val keywordConditions = keywords.map { keyword ->
+                question.statement.contains(keyword)
+            }
+            query.where(keywordConditions.reduce { acc, predicate -> acc.and(predicate) })
+        }
+
+        return query
+            .orderBy(question.modifiedAt.desc())
+            .fetch()
+    }
+}

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepositoryImpl.kt
@@ -29,8 +29,9 @@ class QuestionCustomRepositoryImpl(
                     .selectFrom(tag)
                     .where(tag.name.eq(tagName).and(tag.question.eq(question)))
                     .exists()
-            }.reduce { sub, predicate -> sub.and(predicate) } // reduce: 서브쿼리(sub)들을 and조건으로 결합
-            query.where(tagCondition)
+            }
+            // reduce: 서브쿼리(sub)들을 and조건으로 결합
+            query.where(tagCondition.reduce { sub, predicate -> sub.and(predicate) } )
         }
 
         // 문항 조건: keywords로 들어온 검색어를 모두 포함하는 문항(statement)을 가진 문제 검색

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepositoryImpl.kt
@@ -20,7 +20,7 @@ class QuestionCustomRepositoryImpl(
         val query = jpaQueryFactory
             .selectFrom(question)
             .where(question.member.id.eq(memberId))
-            .leftJoin(question.tags, tag)
+            .leftJoin(question.tags, tag).fetchJoin()
             .distinct()
 
 

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepositoryImpl.kt
@@ -5,12 +5,14 @@ import com.swm_standard.phote.entity.QQuestion
 import com.swm_standard.phote.entity.QTag
 import com.swm_standard.phote.entity.Question
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 @Repository
 class QuestionCustomRepositoryImpl(
     private val jpaQueryFactory: JPAQueryFactory
 ): QuestionCustomRepository{
+    @Transactional(readOnly = true)
     override fun searchQuestionsList(memberId:UUID, tags: List<String>?, keywords: List<String>?): List<Question> {
         val question = QQuestion.question
         val tag = QTag.tag

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionRepository.kt
@@ -9,5 +9,5 @@ import java.time.LocalDateTime
 import java.util.*
 
 @Repository
-interface QuestionRepository: JpaRepository<Question, UUID> {
+interface QuestionRepository: JpaRepository<Question, UUID>, QuestionCustomRepository {
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -7,8 +7,9 @@ import com.swm_standard.phote.entity.Tag
 import com.swm_standard.phote.repository.MemberRepository
 import com.swm_standard.phote.repository.QuestionRepository
 import com.swm_standard.phote.repository.TagRepository
-import jakarta.transaction.Transactional
+
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -46,14 +47,14 @@ class QuestionService(
         return CreateQuestionResponseDto(question.id)
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     fun readQuestionDetail(id: UUID): ReadQuestionDetailResponseDto {
         val question = questionRepository.findById(id).orElseThrow { NotFoundException("questionId","존재하지 않는 UUID") }
 
         return ReadQuestionDetailResponseDto(question)
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     fun searchQuestions(memberId: UUID, tags: List<String>?, keywords: List<String>?): List<Question> {
 
         // 요청을 보낸 멤버가 생성한 문제이고, tags, keywords를 모두 포함하는 문제만 불러옴

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -1,10 +1,7 @@
 package com.swm_standard.phote.service
 
 import com.swm_standard.phote.common.exception.NotFoundException
-import com.swm_standard.phote.dto.CreateQuestionRequestDto
-import com.swm_standard.phote.dto.CreateQuestionResponseDto
-import com.swm_standard.phote.dto.DeleteQuestionResponseDto
-import com.swm_standard.phote.dto.ReadQuestionDetailResponseDto
+import com.swm_standard.phote.dto.*
 import com.swm_standard.phote.entity.Question
 import com.swm_standard.phote.entity.Tag
 import com.swm_standard.phote.repository.MemberRepository
@@ -54,6 +51,15 @@ class QuestionService(
         val question = questionRepository.findById(id).orElseThrow { NotFoundException("questionId","존재하지 않는 UUID") }
 
         return ReadQuestionDetailResponseDto(question)
+    }
+
+    @Transactional
+    fun searchQuestions(memberId: UUID, tags: List<String>?, keywords: List<String>?): List<Question> {
+
+        // 요청을 보낸 멤버가 생성한 문제이고, tags, keywords를 모두 포함하는 문제만 불러옴
+        val questions: List<Question> = questionRepository.searchQuestionsList(memberId, tags, keywords)
+
+        return questions
     }
 
     @Transactional


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- queryDSL을 이용해 문제 검색 기능을 구현했습니다.
  - 요청으로 들어온 tags를 모두 포함하고 문제 문항(statement)에 keywords가 모두 포함되어 있는 문제만을 검색합니다.
  - modifiedAt을 기준으로 최신 문제순으로 정렬되어 리턴합니다.
  - fetch join으로 n+1 문제 해결
---

### ✨ 참고 사항

- **queryDSL 도입 이유**
  - 검색 조건이 복잡하기 때문에 기존 JPA나 JPQL로 쿼리를 작성하기엔 메서드 명이 매우 길어지고, 쿼리가 매우 길어지는 등 한계가 있었습니다.
  - ```tags```와 ```keywords```가 들어올 때도 있고 아닐 때도 있고 태그, 키워드 개수도 요청마다 동적으로 바뀌기 때문에 JPA | JPQL을 사용하면 상황마다 대응할 수 있는 조건을 걸고 메서드들을 복수개로 만들어둬야 합니다. 
  반면 queryDSL에서는 태그, 키워드가 들어오지 않으면 자동으로 ```where조건```을 걸지 않고 복수개가 들어와도 각 상황에 맞게 동작이 가능합니다. 따라서 상황에 맞춰 다이나믹하게 변하는 **동적쿼리**를 만들고자 했습니다. 

위와 같은 이유로 검색 api에선 JPA, JPQL보다 queryDSL이 적합하다고 판단했습니다.

- **구현하면서 어려웠던 점(제가 나중에 보려고 작성..)**

  - 처음에는 아래와 같이 ```in 조건```을 통해 문제의 태그가 검색 요청값으로 들어온 ```tags```에 포함되어 있는 문제를 반환하게 했습니다. 
  그러나 이렇게 작성하면 문제의 태그가 하나라도 ```tags```에 들어있으면 모두 반환되는 문제가 있었습니다. 
  (ex: 문제1: "수학","미적분", 문제2: "수학" 이렇게 태그를 가지고 있을 때 요청 tags로 "수학","미적분"이 들어온다면 문제1, 문제2 모두 반환)
    ```
    if (!tags.isNullOrEmpty()) {
          query.where(tag.name.in(tags))
    }
    ```

  - ```And조건```으로 ```tags```의 모든 값을 다 포함하고 있는 문제만 찾아야 하기 때문에 아래와 같이 reduce메소드로 각 태그에 대한 포함여부 확인 서브쿼리들을 and조건으로 묶어서 연산하도록 했습니다.
    ```
        if (!tags.isNullOrEmpty()) {
            val tagCondition = tags.map { tagName ->
                jpaQueryFactory
                    .selectFrom(tag)
                    .where(tag.name.eq(tagName).and(tag.question.eq(question)))
                    .exists()
            }
            // reduce: 서브쿼리(sub)들을 and조건으로 결합
            query.where(tagCondition.reduce { sub, predicate -> sub.and(predicate) } )
        }
    ```

---

### ⏰ 현재 버그

---

### ✏ Git Close #42 