### PR TITLE
Fix: 문제집 상세에 문제 개수 추가 / 문제 변동 시 문제집 수정일 변경 (Seyeon/swm 79)

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -43,11 +43,9 @@ data class ReadWorkbookDetailResponse(
 
     val emoji: String,
 
-    val createdAt: LocalDateTime,
+    val quantity: Int,
 
     val modifiedAt: LocalDateTime?,
-
-    val questions: List<QuestionSet>,
 )
 
 data class ReadWorkbookListResponse(

--- a/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.*
 import org.hibernate.annotations.ColumnDefault
 import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.DynamicUpdate
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import org.springframework.data.annotation.LastModifiedDate
@@ -13,6 +14,7 @@ import java.util.*
 @Entity
 @SQLDelete(sql = "UPDATE workbook SET deleted_at = NOW() WHERE workbook_uuid = ?")
 @SQLRestriction("deleted_at is NULL")
+@DynamicUpdate
 data class Workbook(
 
     var title: String,
@@ -49,9 +51,12 @@ data class Workbook(
 
     fun decreaseQuantity(){
         this.quantity -= 1
+        modifiedAt = LocalDateTime.now()
     }
 
     fun increaseQuantity(count: Int){
         this.quantity += count
+        modifiedAt = LocalDateTime.now()
     }
+
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -46,16 +46,14 @@ class WorkbookService(
     fun readWorkbookDetail(id: UUID) : ReadWorkbookDetailResponse {
         val workbook = workbookRepository.findById(id).orElseThrow { NotFoundException() }
 
-        val questionSet = questionSetRepository.findAllByWorkbookId(id)
 
         return ReadWorkbookDetailResponse(
             workbook.id,
             workbook.title,
             workbook.description,
             workbook.emoji,
-            workbook.createdAt,
+            workbook.quantity,
             workbook.modifiedAt,
-            questionSet
             )
     }
 

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -99,10 +99,7 @@ class WorkbookService(
         questionSetRepository.findByQuestionIdAndWorkbookId(questionId, workbookId)?.also {
             questionSetRepository.delete(it)
 
-            workbook.apply {
-                decreaseQuantity()
-                workbookRepository.save(this)
-            }
+            workbook.decreaseQuantity()
 
             return DeleteQuestionInWorkbookResponse(workbookId, questionId, LocalDateTime.now())
         }

--- a/src/test/kotlin/com/swm_standard/phote/entity/WorkbookTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/WorkbookTest.kt
@@ -3,7 +3,6 @@ package com.swm_standard.phote.entity
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 
-import org.junit.jupiter.api.Assertions.*
 import java.time.LocalDateTime
 import java.util.*
 
@@ -18,6 +17,7 @@ class WorkbookTest {
         workbook.decreaseQuantity()
 
         Assertions.assertThat(workbook.quantity).isEqualTo(testNum - 1)
+        Assertions.assertThat(workbook.modifiedAt?.second).isEqualTo(LocalDateTime.now().second)
     }
 
     @Test
@@ -30,7 +30,9 @@ class WorkbookTest {
         workbook.increaseQuantity(createdQuestionCnt)
 
         Assertions.assertThat(workbook.quantity).isEqualTo(testNum + createdQuestionCnt)
+        Assertions.assertThat(workbook.modifiedAt?.second).isEqualTo(LocalDateTime.now().second)
     }
+
 
     fun createWorkbook(): Workbook {
         return Workbook(
@@ -45,4 +47,6 @@ class WorkbookTest {
             ), emoji = "contentiones"
         )
     }
+
+
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 문제집 상세 조회 (`readWorkbookDetail`) api에서 문제집 내 문제 개수 (`quantity`) 도 응답으로 함께 보내도록 변경했습니다.
- 문제집 상세 조회 (`readWorkbookDetail`) api에서 속한 문제 목록은 제외했습니다. ➡️ 새로운 api로 뺄 예정!
- 문제 변동 시 문제집 수정일을 변경하도록 했습니다. ➡️ `decreaseQuantity()` , `increaseQuantity()` 내에 수정일 변경 코드를 추가함
---

### ✨ 참고 사항

- `addQuestionsToWorkbook` 에서 **JPA dirty checking** 으로 엔티티를 업데이트해서 `deleteQuestionInWorkbook` 도 같은 방식으로 변경했습니다.
- `Workbook` 엔티티에 `@DynamicUpdate` 을 추가하여 필요한 필드만 업데이트되도록 개선하였습니다.

&nbsp;

> `@DynamicUpdate` 이 없을 때의 쿼리문

```sql
update 
  workbook 
set 
  created_at = ?, 
  deleted_at = ?, 
  description = ?, 
  emoji = ?, 
  member_id = ?, 
  modified_at = ?, 
  quantity = ?, 
  title = ? 
where 
  workbook_uuid = ?
```

&nbsp;

> `@DynamicUpdate` 을 추가했을 때의 쿼리문
```sql
update 
  workbook 
set 
  quantity = ? 
where 
  workbook_uuid = ?
```
---

### ⏰ 현재 버그

x

---

### ✏ Git Close #73 