### PR TITLE
Feat: 구글 첫 로그인 후 바로 회원가입

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
@@ -44,7 +44,8 @@ class AuthController(
         val accessToken = googleAuthService.getTokenFromGoogle(code)
         val userInfo = googleAuthService.getUserInfoFromGoogle(accessToken)
 
-        return BaseResponse(msg = "로그인 성공", data = userInfo)
+        val message = if (userInfo.isMember == false) "회원가입 성공" else "로그인 성공"
+        return BaseResponse(msg = message, data = userInfo)
     }
 
     @GetMapping("/kakao-login")

--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -1,7 +1,6 @@
 package com.swm_standard.phote.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.swm_standard.phote.entity.QuestionSet
 import jakarta.validation.constraints.NotBlank
 import java.time.LocalDateTime
 import java.util.UUID

--- a/src/main/kotlin/com/swm_standard/phote/entity/Member.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Member.kt
@@ -9,9 +9,6 @@ import java.util.UUID
 @Entity
 data class Member(
 
-    @Id @Column(name = "member_uuid", nullable = false, unique = true)
-    val id: UUID = UUID.randomUUID(),
-
     val name: String,
 
     val email: String,
@@ -21,11 +18,15 @@ data class Member(
     @Enumerated(EnumType.STRING)
     val provider: Provider,
 
+){
+    @Id @Column(name = "member_uuid", nullable = false, unique = true)
+    val id: UUID = UUID.randomUUID()
+
     @CreationTimestamp
-    val joinedAt: LocalDateTime = LocalDateTime.now(),
+    val joinedAt: LocalDateTime = LocalDateTime.now()
 
     @JsonIgnore
     val deletedAt: LocalDateTime? = null
-)
+}
 
 

--- a/src/main/kotlin/com/swm_standard/phote/service/GoogleAuthService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/GoogleAuthService.kt
@@ -3,6 +3,8 @@ package com.swm_standard.phote.service
 import com.swm_standard.phote.common.authority.JwtTokenProvider
 import com.swm_standard.phote.dto.GoogleAccessResponseDto
 import com.swm_standard.phote.dto.UserInfoResponseDto
+import com.swm_standard.phote.entity.Member
+import com.swm_standard.phote.entity.Provider
 import com.swm_standard.phote.repository.MemberRepository
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpEntity
@@ -58,6 +60,11 @@ class GoogleAuthService(private val memberRepository: MemberRepository, private 
 
         if (member == null){
             dto.isMember = false
+
+            val save: Member = memberRepository.save(Member(dto.name, dto.email, dto.picture, Provider.GOOGLE))
+            dto.accessToken = jwtTokenProvider.createToken(dto, save.id)
+            dto.userId = save.id
+
         } else {
             dto.isMember = true
             dto.accessToken = jwtTokenProvider.createToken(dto, member.id)


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 구글 소셜 로그인에서 서비스 내 첫 로그인 시 바로 회원가입이 되도록 (DB에 멤버 정보가 저장되도록) 구현했습니다.

**🙌🏻 응답 예시 🙌🏻**
```json
{
  "result": "SUCCESS",
  "status": 200,
  "msg": "회원가입 성공",
  "data": {
    "accessToken": "Bearer eyJhbGciOiJIUzI1sdfe.eyJzdWIiOiJ0cGR1c2RsMTAwAsg45***********JtZW1iZXJJZCI6ImY3ZDNmZWE3LTRkY2UtNGRjNC1iZDZiLWI3NWI4ZmYwMTZiMCIsImlhdCI6MTcyMTAxNzYyOSwiZXhwIjoxNzIxMTA0MDI5fQ.vdC-HW1cHxQUQlyKiCpVFfroKB3AtbhFRdFn-ovbo8A",
    "name": "홍길동",
    "email": "email@gmail.com",
    "picture": "https://lh3.googleusercontent.com/a/ACg8ocJVAAvT***********udVThQgUiEc1q6Z3jGHMYM=s96-c",
    "isMember": false,
    "userId": "f7d3fea7-****-4dc4-bd6b-****8f****b0"
  }
}
```
---

### ✨ 참고 사항

- 문제 풀이 기능이 추가되면 실명과 같이 식별할 수 있는 정보가 추가적으로 필요할 것 같아서 아직 랜덤 닉네임을 반영하지는 않았습니다 (결정하고 반영 예정)

---

### ⏰ 현재 버그

x

---

### ✏ Git Close #69 