### PR TITLE
Feat: readQuestionsInWorkbook

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
@@ -72,4 +72,13 @@ class WorkbookController(private val workbookService: WorkbookService) {
 
         return BaseResponse(msg = "문제집의 문제 순서 변경 성공", data = response)
     }
+
+    @GetMapping("/workbook/questions/{workbookId}")
+    fun readQuestionsInWorkbook(@PathVariable(required = true) workbookId: UUID): BaseResponse<List<ReadQuestionsInWorkbookResponse>> {
+
+        val response = workbookService.readQuestionsInWorkbook(workbookId)
+
+        return BaseResponse(msg = "문제집의 문제 목록 조회 성공", data = response)
+
+    }
 }

--- a/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
@@ -1,6 +1,7 @@
 package com.swm_standard.phote.dto
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.swm_standard.phote.entity.Category
 import com.swm_standard.phote.entity.Question
 import com.swm_standard.phote.entity.Tag
 import jakarta.validation.constraints.NotBlank
@@ -14,7 +15,7 @@ data class ReadQuestionDetailResponseDto(
     val image: String? = null,
     val options: JsonNode? = null,
     val answer: String,
-    val category: String,
+    val category: Category,
     val tags: List<Tag>? = null,
     val memo: String? = null
 ) {
@@ -41,7 +42,7 @@ data class CreateQuestionRequestDto(
     @field:NotBlank(message = "statement 미입력")
     val statement: String,
     @field:NotBlank(message = "category 미입력")
-    val category: String,
+    val category: Category,
     val options: JsonNode? = null,
     @field:NotBlank(message = "answer 미입력")
     val answer: String,

--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -1,6 +1,9 @@
 package com.swm_standard.phote.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.JsonNode
+import com.swm_standard.phote.entity.Category
+import com.swm_standard.phote.entity.Tag
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.PositiveOrZero
 import java.time.LocalDateTime
@@ -95,3 +98,21 @@ data class UpdateQuestionSequenceRequest(
 data class UpdateQuestionSequenceResponse(
     val id: UUID,
 )
+
+data class ReadQuestionsInWorkbookResponse(
+    val questionSetId: UUID,
+
+    val questionId: UUID,
+
+    val statement: String,
+
+    val options: JsonNode?,
+
+    val image: String?,
+
+    val category: Category,
+
+    val sequence: Int,
+
+    val tags: List<Tag>,
+    )

--- a/src/main/kotlin/com/swm_standard/phote/entity/Category.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Category.kt
@@ -1,0 +1,5 @@
+package com.swm_standard.phote.entity
+
+enum class Category {
+    MULTIPLE, ESSAY
+}

--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -38,7 +38,8 @@ data class Question(
 
     val answer: String,
 
-    val category: String,
+    @Enumerated(EnumType.STRING)
+    val category: Category,
 
     @OneToMany(mappedBy = "question", cascade = [CascadeType.REMOVE])
     @JsonIgnore

--- a/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
@@ -6,6 +6,7 @@ import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import java.time.LocalDateTime
+import java.util.UUID
 
 @Entity
 @SQLDelete(sql = "UPDATE question_set SET deleted_at = NOW() WHERE question_set_id = ?")
@@ -25,9 +26,9 @@ data class QuestionSet(
 
     ){
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
     @Column(name = "questionSet_id")
-    val id: Long = 0
+    val id: UUID = UUID.randomUUID()
 
 
     @CreationTimestamp

--- a/src/main/kotlin/com/swm_standard/phote/entity/Tag.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Tag.kt
@@ -12,6 +12,7 @@ import java.time.LocalDateTime
 data class Tag(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "tag_id", unique = true)
+    @JsonIgnore
     val id: Long = 0L,
 
     val name: String,

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetRepository.kt
@@ -8,4 +8,6 @@ import java.util.UUID
 interface QuestionSetRepository: JpaRepository<QuestionSet, UUID> {
 
     fun findByQuestionIdAndWorkbookId(questionId: UUID, workbookId: UUID): QuestionSet?
+
+    fun findByWorkbookIdOrderBySequence(workbookId: UUID): List<QuestionSet>
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -125,4 +125,23 @@ class WorkbookService(
 
         return workbookId
     }
+
+    fun readQuestionsInWorkbook(workbookId: UUID): List<ReadQuestionsInWorkbookResponse> {
+
+        workbookRepository.findById(workbookId).orElseThrow{ InvalidInputException(fieldName = "workboook", message = "id를 재확인해주세요.")}
+        val questionSets: List<QuestionSet> = questionSetRepository.findByWorkbookIdOrderBySequence(workbookId)
+
+        return questionSets.map { set ->
+            ReadQuestionsInWorkbookResponse(
+                set.id,
+                set.question.id,
+                set.question.statement,
+                set.question.options,
+                set.question.image,
+                set.question.category,
+                set.sequence,
+                set.question.tags
+            )
+        }
+    }
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- workbookId로 문제집 내의 문제 목록을 조회하는 기능을 구현했습니다. 
-  questionSetId도 포함했습니다. ➡️ 순서 변경 시에 사용하면 됨!
- `question`의 `category` 필드를 Enum (`MULTIPLE` (객관식) , `ESSAY` (주관식)) 으로 변경했습니다.
- 문제 조회 시에 `tag`는 name 필드만 사용하기 때문에 tag Id는 제외하도록 했습니다.

&nbsp;

#### 🙌🏻 응답 예시 🙌🏻

<img width="400" alt="스크린샷 2024-07-16 오후 6 33 27" src="https://github.com/user-attachments/assets/383a1661-6718-4f73-b41e-67078aca8f83">

---

### ✨ 참고 사항

- 이제 questionSet id도 외부에서 사용하게 되므로 `id`를 **Long** 타입에서 **UUID** 타입으로 변경했습니다.

---

### ⏰ 현재 버그

x

---

### ✏ Git Close #79