### PR TITLE
Fix: 구글 첫 로그인 시 랜덤 닉네임, 이미지 부여

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/common/module/ProfileImageGenerator.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/module/ProfileImageGenerator.kt
@@ -1,4 +1,4 @@
-package com.swm_standard.phote.external.randomprofile
+package com.swm_standard.phote.common.module
 
 class ProfileImageGenerator {
 

--- a/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
@@ -33,7 +33,7 @@ class AuthController(
     @GetMapping("/google-login")
     fun googleLogin(): RedirectView {
         val redirectView = RedirectView()
-        redirectView.url = "https://accounts.google.com/o/oauth2/v2/auth?client_id=$clientId&response_type=code&redirect_uri=$redirectUri&scope=https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email"
+        redirectView.url = "https://accounts.google.com/o/oauth2/v2/auth?client_id=$clientId&response_type=code&redirect_uri=$redirectUri&scope=https://www.googleapis.com/auth/userinfo.email"
 
         return redirectView
     }

--- a/src/main/kotlin/com/swm_standard/phote/dto/AuthDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/AuthDtos.kt
@@ -3,7 +3,7 @@ package com.swm_standard.phote.dto
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.UUID
 
-data class GoogleAccessResponseDto(
+data class GoogleAccessResponse(
     @JsonProperty("access_token")
     val accessToken: String,
 
@@ -22,9 +22,10 @@ data class GoogleAccessResponseDto(
 
 data class UserInfoResponseDto(
     var accessToken: String? = null,
-    val name: String,
+    var name: String?,
     val email: String,
-    val picture: String,
-    var isMember: Boolean?,
+    var picture: String,
+    var isMember: Boolean? = true,
     var userId: UUID?,
 )
+

--- a/src/main/kotlin/com/swm_standard/phote/external/randomprofile/ProfileImageGenerator.kt
+++ b/src/main/kotlin/com/swm_standard/phote/external/randomprofile/ProfileImageGenerator.kt
@@ -1,0 +1,22 @@
+package com.swm_standard.phote.external.randomprofile
+
+class ProfileImageGenerator {
+
+    val eyes: List<String> = listOf(
+    "variant01", "variant02", "variant03", "variant04","variant05", "variant06", "variant07", "variant08", "variant09",
+        "variant10", "variant11", "variant12"
+    )
+
+    val mouth: List<String> = listOf(
+        "happy01", "happy02", "happy03", "happy04", "happy05", "happy06", "happy07", "happy08", "happy09",
+        "happy10", "happy11", "happy12", "happy13"
+    )
+
+    val seed: List<String> = listOf("Felix", "Aneka")
+
+    val color: List<String> = listOf("b6e3f4", "c0aede", "d1d4f9", "ffd5dc", "ffdfbf", "cb9e6e", "eac393", "ffdbac", "f5cfa0")
+
+    fun imageGenerator(): String {
+        return "https://api.dicebear.com/9.x/pixel-art-neutral/svg?seed=${seed.random()}&eyes=${eyes.random()}&mouth=${mouth.random()}&backgroundColor=${color.random()}"
+    }
+}

--- a/src/main/kotlin/com/swm_standard/phote/service/GoogleAuthService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/GoogleAuthService.kt
@@ -6,7 +6,7 @@ import com.swm_standard.phote.dto.GoogleAccessResponse
 import com.swm_standard.phote.dto.UserInfoResponseDto
 import com.swm_standard.phote.entity.Member
 import com.swm_standard.phote.entity.Provider
-import com.swm_standard.phote.external.randomprofile.ProfileImageGenerator
+import com.swm_standard.phote.common.module.ProfileImageGenerator
 import com.swm_standard.phote.repository.MemberRepository
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpEntity

--- a/src/main/kotlin/com/swm_standard/phote/service/GoogleAuthService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/GoogleAuthService.kt
@@ -1,10 +1,12 @@
 package com.swm_standard.phote.service
 
 import com.swm_standard.phote.common.authority.JwtTokenProvider
-import com.swm_standard.phote.dto.GoogleAccessResponseDto
+import com.swm_standard.phote.common.module.NicknameGenerator
+import com.swm_standard.phote.dto.GoogleAccessResponse
 import com.swm_standard.phote.dto.UserInfoResponseDto
 import com.swm_standard.phote.entity.Member
 import com.swm_standard.phote.entity.Provider
+import com.swm_standard.phote.external.randomprofile.ProfileImageGenerator
 import com.swm_standard.phote.repository.MemberRepository
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpEntity
@@ -30,11 +32,11 @@ class GoogleAuthService(private val memberRepository: MemberRepository, private 
         val params: MutableMap<String, Any> = HashMap()
 
         val googleTokenRequest: HttpEntity<MutableMap<String, Any>> = HttpEntity(params, headers)
-        val response: GoogleAccessResponseDto = restTemplate.exchange(
+        val response: GoogleAccessResponse = restTemplate.exchange(
             "https://oauth2.googleapis.com/token?grant_type=authorization_code&client_id=$clientId&client_secret=$clientSecret&code=$code&redirect_uri=$redirectUri",
             HttpMethod.POST,
             googleTokenRequest,
-            GoogleAccessResponseDto::class.java
+            GoogleAccessResponse::class.java
         ).body!!
 
         return response.accessToken
@@ -56,20 +58,20 @@ class GoogleAuthService(private val memberRepository: MemberRepository, private 
             UserInfoResponseDto::class.java
         ).body!!
 
-        val member = memberRepository.findByEmail(dto.email)
+
+        var member = memberRepository.findByEmail(dto.email)
 
         if (member == null){
             dto.isMember = false
+            dto.picture = ProfileImageGenerator().imageGenerator()
+            val initName = NicknameGenerator().randomNickname()
 
-            val save: Member = memberRepository.save(Member(dto.name, dto.email, dto.picture, Provider.GOOGLE))
-            dto.accessToken = jwtTokenProvider.createToken(dto, save.id)
-            dto.userId = save.id
-
-        } else {
-            dto.isMember = true
-            dto.accessToken = jwtTokenProvider.createToken(dto, member.id)
-            dto.userId = member.id
+            member = memberRepository.save(Member(initName, dto.email, dto.picture , Provider.GOOGLE))
         }
+
+        dto.accessToken = jwtTokenProvider.createToken(dto, member.id)
+        dto.userId = member.id
+        dto.name = member.name
 
         return dto
     }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 구글에서 email 정보만 받는 걸로 변경했습니다.
- https://www.dicebear.com/ 의 랜덤 프로필 이미지 api를 사용하여 사용자에게 부여했습니다. 괜찮다면 카카오 로그인에서도 같이 사용하면 좋을 것 같습니다!
- `GoogleAuthService`의 `getUserInfoFromGoogle()` 메서드를  살짝 리팩토링했습니다.
---

### ✨ 참고 사항

- `isMember` 가 회원가입을 별도로 한다고 생각하고 추가했던 필드인데 이제는 필요없으려나요? responseBody에 msg 를 멤버 여부에 따라 구분하긴 하더라구요

---

### ⏰ 현재 버그

x

---

### ✏ Git Close #86 