### PR TITLE
Feat: seachQuestionsToAdd 구현

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
@@ -43,6 +43,14 @@ class QuestionController(
         return BaseResponse(msg = "문제 검색 성공", data=questionService.searchQuestions(memberId, tags, keywords))
     }
 
+    @GetMapping("/questions/workbook/{workbookId}")
+    fun searchQuestionsToAdd(@MemberId memberId: UUID,
+                             @PathVariable(required = true) workbookId: UUID,
+                             @RequestParam(required = false) tags: List<String>? = null,
+                             @RequestParam(required = false) keywords: List<String>? = null): BaseResponse<List<SearchQuestionsToAddResponseDto>> {
+        return BaseResponse(msg = "문제집에 추가할 문제 목록 검색 성공", data = questionService.searchQuestionsToAdd(memberId, workbookId, tags, keywords))
+    }
+
     @DeleteMapping("/question/{id}")
     fun deleteQuestion(@PathVariable(required = true) id: UUID)
     : BaseResponse<DeleteQuestionResponseDto>{

--- a/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
@@ -53,3 +53,16 @@ data class CreateQuestionRequestDto(
 data class CreateQuestionResponseDto(
     val id: UUID
 )
+
+data class SearchQuestionsToAddResponseDto(
+    val createdAt: LocalDateTime,
+    val modifiedAt: LocalDateTime? = null,
+    val statement: String,
+    val image: String? = null,
+    val options: JsonNode? = null,
+    val answer: String,
+    val category: Category,
+    val tags: List<Tag>? = null,
+    val memo: String? = null,
+    var isContain: Boolean = false
+)

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepository.kt
@@ -1,8 +1,11 @@
 package com.swm_standard.phote.repository
 
+import com.swm_standard.phote.dto.SearchQuestionsToAddResponseDto
 import com.swm_standard.phote.entity.Question
 import java.util.*
 
 interface QuestionCustomRepository {
     fun searchQuestionsList(memberId: UUID, tags: List<String>?, keywords: List<String>?): List<Question>
+
+    fun searchQuestionsToAddList(memberId: UUID, workbookId: UUID, tags: List<String>?, keywords: List<String>?): List<SearchQuestionsToAddResponseDto>
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -64,6 +64,14 @@ class QuestionService(
         return questions
     }
 
+    @Transactional(readOnly = true)
+    fun searchQuestionsToAdd(memberId: UUID, workbookId: UUID, tags: List<String>?, keywords: List<String>?): List<SearchQuestionsToAddResponseDto> {
+
+        val questions: List<SearchQuestionsToAddResponseDto> = questionRepository.searchQuestionsToAddList(memberId, workbookId, tags, keywords)
+
+        return questions
+    }
+
     @Transactional
     fun deleteQuestion(id: UUID): DeleteQuestionResponseDto {
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- searchQuestionsToAdd를 구현했습니다.
- queryDSL 사용했습니다.
- 전체적인 로직
  - 1. 문제집에 포함되어 있는 문제 조회
  - 2. 유저가 생성한 모든 문제 중 조건(태그검색 | 키워드검색)에 맞는 문제 조회(이전에 만든 searchQuestionsList 함수 이용)
  - 3. a에서 조회한 문제와 b를 비교하여 둘 다 포함되어 있는 문제라면 isContain변수를 true로 리턴
---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close #83 