### PR TITLE
Fix: createQuestion api의 request에서 category NotBlank에서 NotNull로 변경

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
@@ -47,7 +47,7 @@ class CustomExceptionHandler {
     @ExceptionHandler(BadRequestException::class)
     protected fun badRequestException(ex: BadRequestException) : ResponseEntity<BaseResponse<Map<String, String>>> {
         val errors = mapOf(ex.fieldName to (ex.message ?: "Not Exception Message"))
-        return ResponseEntity(BaseResponse(ErrorCode.BAD_REQUEST.name, ErrorCode.BAD_REQUEST.statusCode, ex.message ?: ErrorCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
+        return ResponseEntity(BaseResponse(ErrorCode.ERROR.name, ErrorCode.BAD_REQUEST.statusCode, ex.message ?: ErrorCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
 
     }
 
@@ -69,7 +69,7 @@ class CustomExceptionHandler {
     @ExceptionHandler(NotFoundException::class)
     protected fun notFoundException(ex: NotFoundException) : ResponseEntity<BaseResponse<Map<String, String>>> {
         val errors = mapOf(ex.fieldName to (ex.message ?: "Not Exception Message"))
-        return ResponseEntity(BaseResponse(ErrorCode.NOT_FOUND.name, ErrorCode.NOT_FOUND.statusCode, ex.message ?: ErrorCode.NOT_FOUND.msg, errors), HttpStatus.NOT_FOUND)
+        return ResponseEntity(BaseResponse(ErrorCode.ERROR.name, ErrorCode.NOT_FOUND.statusCode, ex.message ?: ErrorCode.NOT_FOUND.msg, errors), HttpStatus.NOT_FOUND)
 
     }
 
@@ -91,7 +91,7 @@ class CustomExceptionHandler {
     protected fun methodArgumentTypeMismatchException(ex: MethodArgumentTypeMismatchException) : ResponseEntity<BaseResponse<Map<String, String>>> {
 
         val errors = mapOf(ex.name to (ex.message ?: "Not Exception Message"))
-        return ResponseEntity(BaseResponse(ErrorCode.BAD_REQUEST.name, ErrorCode.BAD_REQUEST.statusCode, ErrorCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
+        return ResponseEntity(BaseResponse(ErrorCode.ERROR.name, ErrorCode.BAD_REQUEST.statusCode, ErrorCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
 
     }
 
@@ -99,7 +99,7 @@ class CustomExceptionHandler {
     protected fun httpMessageNotReadableException(ex: HttpMessageNotReadableException) : ResponseEntity<BaseResponse<Map<String, String>>> {
 
         val errors = mapOf("" to (ex.message ?: "Not Exception Message"))
-        return ResponseEntity(BaseResponse(ErrorCode.BAD_REQUEST.name, ErrorCode.BAD_REQUEST.statusCode, ErrorCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
+        return ResponseEntity(BaseResponse(ErrorCode.ERROR.name, ErrorCode.BAD_REQUEST.statusCode, ErrorCode.BAD_REQUEST.msg, errors), HttpStatus.BAD_REQUEST)
 
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
@@ -5,6 +5,7 @@ import com.swm_standard.phote.entity.Category
 import com.swm_standard.phote.entity.Question
 import com.swm_standard.phote.entity.Tag
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import java.time.LocalDateTime
 import java.util.*
 
@@ -41,7 +42,7 @@ class DeleteQuestionResponseDto (
 data class CreateQuestionRequestDto(
     @field:NotBlank(message = "statement 미입력")
     val statement: String,
-    @field:NotBlank(message = "category 미입력")
+    @field:NotNull(message = "category 미입력")
     val category: Category,
     val options: JsonNode? = null,
     @field:NotBlank(message = "answer 미입력")

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -24,6 +24,9 @@ class QuestionService(
     fun createQuestion(memberId:UUID, request: CreateQuestionRequestDto, imageUrl: String?)
     : CreateQuestionResponseDto {
 
+        println("여기")
+        println(request)
+
         // 문제 생성 유저 확인
         val member = memberRepository.findById(memberId).orElseThrow { NotFoundException("존재하지 않는 member") }
 

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -24,9 +24,6 @@ class QuestionService(
     fun createQuestion(memberId:UUID, request: CreateQuestionRequestDto, imageUrl: String?)
     : CreateQuestionResponseDto {
 
-        println("여기")
-        println(request)
-
         // 문제 생성 유저 확인
         val member = memberRepository.findById(memberId).orElseThrow { NotFoundException("존재하지 않는 member") }
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- category가 enum(MULTIPLE, ESSAY)로 변경되면서 기존 api가 작동하지 않았는데 원인을 알아보니 @NotBlank 어노테이션은 문자열에 적용되는거라 이넘타입에는 사용할 수 없다네용. 그래서 @NotNull로 변경했습니다
- 전에 응답으로 오는 result 다 ERROR로 맞추자 한게 갑자기 생각나서 수정했습니당
---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close #90 