### PR TITLE
Feat: updateQuestionSequence 에서 questionSetId를 사용하도록 변경

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
@@ -13,11 +13,11 @@ import java.util.UUID
 @SQLRestriction("deleted_at is NULL")
 data class QuestionSet(
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id")
     val question: Question,
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "workbook_id")
     @JsonIgnore
     val workbook: Workbook,
@@ -27,7 +27,7 @@ data class QuestionSet(
     ){
 
     @Id
-    @Column(name = "questionSet_id")
+    @Column(name = "question_set_id", nullable = false, unique = true)
     val id: UUID = UUID.randomUUID()
 
 

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetRepository.kt
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 import java.util.UUID
 
-interface QuestionSetRepository: JpaRepository<QuestionSet, UUID> {
+interface QuestionSetRepository: JpaRepository<QuestionSet, UUID>, QuestionSetCustomRepository {
 
     fun findByQuestionIdAndWorkbookId(questionId: UUID, workbookId: UUID): QuestionSet?
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- updateQuestionSequence api에서 `questionSetId` 를 사용하도록 변경했습니다.
- `questionSetCustomRespository` 를 생성하면서 이걸 직접 사용했었는데 `questionSetRepository` 에 종속?시켜서 `questionSetRepository` 에서 다 처리할 수 있도록 고쳤습니다.
- `questionSet` 에서 `workbook`, `member` 의 `fetchtype` 을 **Lazy** 로 변경했습니다. (찾아올 필요가 없는 데이터들임)

&nbsp;

**🙌🏻 응답 예시 🙌🏻**
<img width="400" alt="스크린샷 2024-07-18 오후 4 22 18" src="https://github.com/user-attachments/assets/16447196-1a6f-4bb0-a1f8-9cdf0907cc6c">

---

### ✨ 참고 사항
#### 프론트 참고사항 @Goonco 
1. requestBody 에서 `questionId` -> `questionSetId` 로 바뀌었지만 api 엔드포인트에 `workbookId` 는 이전과 같이 붙여서 요청보내야합니다

**사유** : 문제집 내 문제 개수만큼 빠지지않고 담았는지 확인을 해야하는데 해당 필드가 workbook 엔티티에 있음

2. sequence는 **0 이상의 정수** 입니다.
3. sequence가 중복되는지 검증하기엔 오버헤드가 클 것 같아서 예외처리를 따로 두지 않았습니다. **주의 요망!!!**

---

### ⏰ 현재 버그

x

---

### ✏ Git Close
- #87 