### PR TITLE
Feat: matchEmojiByTitle

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/common/authority/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/authority/JwtTokenProvider.kt
@@ -84,7 +84,6 @@ class JwtTokenProvider {
                 is IllegalArgumentException -> {}
                 else -> {}
             }
-            println(e.message)
         }
         return false
     }

--- a/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
@@ -6,7 +6,6 @@ import com.swm_standard.phote.common.responsebody.BaseResponse
 import com.swm_standard.phote.dto.*
 import com.swm_standard.phote.service.WorkbookService
 import jakarta.validation.Valid
-import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
 import java.util.*
 
@@ -15,14 +14,8 @@ import java.util.*
 class WorkbookController(private val workbookService: WorkbookService) {
 
     @PostMapping("/workbook")
-    fun createWorkbook(@Valid @RequestBody request: CreateWorkbookRequest, authentication: Authentication): BaseResponse<CreateWorkbookResponse> {
-
-        val workbook = workbookService.createWorkbook(
-            request.title,
-            request.description,
-            request.emoji,
-            authentication.name
-        )
+    fun createWorkbook(@Valid @RequestBody request: CreateWorkbookRequest, @MemberId memberId: UUID): BaseResponse<CreateWorkbookResponse> {
+        val workbook = workbookService.createWorkbook(request, memberId)
 
         return BaseResponse(msg = "문제집 생성 성공", data = workbook)
     }

--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -18,14 +18,10 @@ data class CreateWorkbookRequest(
     @JsonProperty("description")
     private val _description: String?,
 
-    @JsonProperty("emoji")
-    private val _emoji: String?,
 ) {
     val title: String get() = _title!!
 
     val description: String get() = _description ?: ""
-
-    val emoji: String get() = _emoji ?: "📚"
 }
 
 data class CreateWorkbookResponse(

--- a/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.*
 import org.hibernate.annotations.ColumnDefault
 import org.hibernate.annotations.CreationTimestamp
-import org.hibernate.annotations.DynamicUpdate
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import org.springframework.data.annotation.LastModifiedDate
@@ -25,8 +24,6 @@ data class Workbook(
     @JsonIgnore
     val member: Member,
 
-    var emoji: String,
-
 ){
 
     @Id @Column(name = "workbook_uuid", nullable = false, unique = true)
@@ -35,6 +32,9 @@ data class Workbook(
     @OneToMany(mappedBy = "workbook", cascade = [(CascadeType.REMOVE)])
     @OrderBy("sequence asc")
     val questionSet: List<QuestionSet>? = null
+
+    var emoji: String = "📚"
+
 
     @ColumnDefault(value = "0")
     var quantity: Int = 0
@@ -59,5 +59,21 @@ data class Workbook(
     }
 
     fun compareQuestionQuantity(num: Int) = num == this.quantity
+
+    fun matchEmojiByTitle(){
+        val math: List<String> = listOf("수학", "math", "미적분", "확통", "수1", "수2", "기하", "대수")
+        val language: List<String> = listOf("국어", "언매", "화작", "비문학", "문학", "독서", "듣기", "영어", "eng", "토익", "외국")
+        val science: List<String> = listOf("과학", "화학", "생물", "생명", "물리", "지구")
+
+        println("math.size = ${math.size}")
+        println("math.filter { it in title }.size = ${math.filter { !title.contains(it) }.size}")
+        emoji = when {
+            math.size != math.filter { !title.contains(it) }.size -> "➗"
+            language.size != language.filter { !title.contains(it) }.size -> "💬"
+            science.size != science.filter { !title.contains(it) }.size ->  "🧪"
+            else -> "📚"
+        }
+
+    }
 
 }

--- a/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
@@ -65,8 +65,6 @@ data class Workbook(
         val language: List<String> = listOf("국어", "언매", "화작", "비문학", "문학", "독서", "듣기", "영어", "eng", "토익", "외국")
         val science: List<String> = listOf("과학", "화학", "생물", "생명", "물리", "지구")
 
-        println("math.size = ${math.size}")
-        println("math.filter { it in title }.size = ${math.filter { !title.contains(it) }.size}")
         emoji = when {
             math.size != math.filter { !title.contains(it) }.size -> "➗"
             language.size != language.filter { !title.contains(it) }.size -> "💬"

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -23,10 +23,12 @@ class WorkbookService(
 ) {
 
     @Transactional
-    fun createWorkbook(title: String, description: String?, emoji: String, memberEmail: String): CreateWorkbookResponse {
-        val member = memberRepository.findByEmail(memberEmail) ?: throw NotFoundException()
-        val workbook = workbookRepository.save(Workbook(title, description, member, emoji))
-
+    fun createWorkbook(request: CreateWorkbookRequest, memberId: UUID): CreateWorkbookResponse {
+        val member = memberRepository.findById(memberId).orElseThrow { NotFoundException(fieldName = "member")}
+        val workbook = Workbook(request.title, request.description, member).apply {
+            matchEmojiByTitle()
+            workbookRepository.save(this)
+        }
         return CreateWorkbookResponse(workbook.id)
     }
 
@@ -133,6 +135,7 @@ class WorkbookService(
 
         workbook.title = request.title
         workbook.description = request.description
+        workbook.matchEmojiByTitle()
 
         return UpdateWorkbookDetailResponse(workbookId)
     }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 문제집 등록, 정보 수정 시 제목에 맞게 이모지가 자동 변경되도록 구현했습니다.
- `createWorkbook` 에서 서비스에 dto 자체를 넘겨주는 것으로 리팩토링했습니다.

&nbsp;

<img width="328" alt="스크린샷 2024-07-18 오후 5 36 15" src="https://github.com/user-attachments/assets/5f448207-38d0-477b-a048-809c8d24e466">

- 수학 관련 : ➗
- 언어 관련 : 💬
- 과학 관련 : 🧪
- (이외에는 특징을 살려낼 수 있는 이모지가 없는 것 같습니다..!)
- 그 외 : 📚 

---

### ✨ 참고 사항

- 살짝 하드코딩한 느낌인데 더 유연하게 처리할 수 있는 방법을 구상해봐야할 것 같습니다. 
- `Workbook`의 `matchEmojiByTitle()` 에서 일단 이모지를 반환받고 `workbook.emoji(반환받은 이모지)` 와 같이 다시 주입해줘야하나 고민하다가 엔티티 내에서 바로 변경 적용되도록 구현했습니다. 

---

### ⏰ 현재 버그

- 매칭되는 언어가 동시에 존재할 경우 (e.g. "**수학 국어 풀이**"), 수학 키워드에서 먼저 포착돼서 수학 이모지로 저장됩니다. 이 경우에 공통 이모지 `📚` 로 처리할 수 있는 깔끔한 방법이 아직은 안떠오르네용..

---

### ✏ Git Close
- #95 