### PR TITLE
Fix: .allowedOrigins -> .allowedOriginPatterns

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/common/resolver/WebMvcConfig.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/resolver/WebMvcConfig.kt
@@ -16,7 +16,7 @@ class WebMvcConfig(
 
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/**")
-            .allowedOrigins("*")
+            .allowedOriginPatterns("*")
             .allowedMethods("*")
             .allowCredentials(true)
     }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 스프링 부트에서 CORS 설정 시 `.allowCredentials(true)` 와 `allowedOrigins("*")` 를 동시에 사용할 수 없도록 업데
이트 되었다고 합니다. 그래서 대신 `allowedOriginPatterns()`를 사용하는 것으로 변경했습니다.
---

### ✨ 참고 사항

https://kim6394.tistory.com/273

---

### ⏰ 현재 버그

x.. maybe

---

### ✏ Git Close
- #101 