### PR TITLE
Feat: transformQuestion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,14 +47,14 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
     implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
 
-	//querydsl
-	implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
-	kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
-	kapt("jakarta.annotation:jakarta.annotation-api")
-	kapt("jakarta.persistence:jakarta.persistence-api")
+    // querydsl
+    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+    kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
+    kapt("jakarta.annotation:jakarta.annotation-api")
+    kapt("jakarta.persistence:jakarta.persistence-api")
 
-	//swagger
-	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+    // swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
 }
 
 allOpen {

--- a/src/main/kotlin/com/swm_standard/phote/common/exception/ChatGptErrorException.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/exception/ChatGptErrorException.kt
@@ -1,0 +1,8 @@
+package com.swm_standard.phote.common.exception
+
+class ChatGptErrorException(
+    val fieldName: String = "",
+    message: String = "ChatGPT 실행 오류 발생",
+) : RuntimeException(message) {
+    constructor(message: String) : this(message = message, fieldName = "")
+}

--- a/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/exception/CustomExceptionHandler.kt
@@ -23,7 +23,7 @@ class CustomExceptionHandler {
         ex.bindingResult.allErrors.forEach { error ->
             val fieldName = (error as FieldError).field
             val errorMessage = error.defaultMessage
-            errors[fieldName] = errorMessage ?: "Not Exception Message"
+            errors[fieldName] = errorMessage ?: "Not Exception RequestMessage"
         }
 
         return ResponseEntity(
@@ -39,7 +39,7 @@ class CustomExceptionHandler {
 
     @ExceptionHandler(InvalidInputException::class)
     protected fun invalidInputException(ex: InvalidInputException): ResponseEntity<BaseResponse<Map<String, String>>> {
-        val errors = mapOf(ex.fieldName to (ex.message ?: "Not Exception Message"))
+        val errors = mapOf(ex.fieldName to (ex.message ?: "Not Exception RequestMessage"))
         return ResponseEntity(
             BaseResponse(
                 ErrorCode.ERROR.name,
@@ -53,7 +53,7 @@ class CustomExceptionHandler {
 
     @ExceptionHandler(Exception::class)
     protected fun defaultException(ex: Exception): ResponseEntity<BaseResponse<Map<String, String>>> {
-        val errors = mapOf("서버 내 오류" to (ex.message ?: "Not Exception Message"))
+        val errors = mapOf("서버 내 오류" to (ex.message ?: "Not Exception RequestMessage"))
         return ResponseEntity(
             BaseResponse(
                 ErrorCode.ERROR.name,
@@ -67,7 +67,7 @@ class CustomExceptionHandler {
 
     @ExceptionHandler(BadRequestException::class)
     protected fun badRequestException(ex: BadRequestException): ResponseEntity<BaseResponse<Map<String, String>>> {
-        val errors = mapOf(ex.fieldName to (ex.message ?: "Not Exception Message"))
+        val errors = mapOf(ex.fieldName to (ex.message ?: "Not Exception RequestMessage"))
         return ResponseEntity(
             BaseResponse(
                 ErrorCode.ERROR.name,
@@ -81,7 +81,7 @@ class CustomExceptionHandler {
 
     @ExceptionHandler(NoResourceFoundException::class)
     protected fun noResourceException(ex: Exception): ResponseEntity<BaseResponse<Map<String, String>>> {
-        val errors = mapOf("id" to (ex.message ?: "Not Exception Message"))
+        val errors = mapOf("id" to (ex.message ?: "Not Exception RequestMessage"))
         return ResponseEntity(
             BaseResponse(
                 ErrorCode.ERROR.name,
@@ -97,7 +97,7 @@ class CustomExceptionHandler {
     protected fun alreadyDeletedException(
         ex: AlreadyExistedException,
     ): ResponseEntity<BaseResponse<Map<String, String>>> {
-        val errors = mapOf(ex.fieldName to (ex.message ?: "Not Exception Message"))
+        val errors = mapOf(ex.fieldName to (ex.message ?: "Not Exception RequestMessage"))
         return ResponseEntity(
             BaseResponse(
                 ErrorCode.ERROR.name,
@@ -111,7 +111,7 @@ class CustomExceptionHandler {
 
     @ExceptionHandler(NotFoundException::class)
     protected fun notFoundException(ex: NotFoundException): ResponseEntity<BaseResponse<Map<String, String>>> {
-        val errors = mapOf(ex.fieldName to (ex.message ?: "Not Exception Message"))
+        val errors = mapOf(ex.fieldName to (ex.message ?: "Not Exception RequestMessage"))
         return ResponseEntity(
             BaseResponse(
                 ErrorCode.ERROR.name,
@@ -132,7 +132,7 @@ class CustomExceptionHandler {
         ex.allErrors.forEach { error ->
             val fieldName = (error as FieldError).field
             val errorMessage = error.defaultMessage
-            errors[fieldName] = errorMessage ?: "Not Exception Message"
+            errors[fieldName] = errorMessage ?: "Not Exception RequestMessage"
         }
 
         return ResponseEntity(
@@ -145,7 +145,7 @@ class CustomExceptionHandler {
     protected fun methodArgumentTypeMismatchException(
         ex: MethodArgumentTypeMismatchException,
     ): ResponseEntity<BaseResponse<Map<String, String>>> {
-        val errors = mapOf(ex.name to (ex.message ?: "Not Exception Message"))
+        val errors = mapOf(ex.name to (ex.message ?: "Not Exception RequestMessage"))
         return ResponseEntity(
             BaseResponse(
                 ErrorCode.ERROR.name,
@@ -161,7 +161,7 @@ class CustomExceptionHandler {
     protected fun httpMessageNotReadableException(
         ex: HttpMessageNotReadableException,
     ): ResponseEntity<BaseResponse<Map<String, String>>> {
-        val errors = mapOf("" to (ex.message ?: "Not Exception Message"))
+        val errors = mapOf("" to (ex.message ?: "Not Exception RequestMessage"))
         return ResponseEntity(
             BaseResponse(
                 ErrorCode.ERROR.name,
@@ -170,6 +170,20 @@ class CustomExceptionHandler {
                 errors,
             ),
             HttpStatus.BAD_REQUEST,
+        )
+    }
+
+    @ExceptionHandler(ChatGptErrorException::class)
+    protected fun chatGptErrorException(ex: ChatGptErrorException): ResponseEntity<BaseResponse<Map<String, String>>> {
+        val errors = mapOf(ex.fieldName to (ex.message ?: "Not Exception RequestMessage"))
+        return ResponseEntity(
+            BaseResponse(
+                ErrorCode.ERROR.name,
+                ErrorCode.BAD_GATEWAY.statusCode,
+                ErrorCode.BAD_GATEWAY.msg,
+                errors,
+            ),
+            HttpStatus.BAD_GATEWAY,
         )
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/common/responsebody/EnumStatus.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/responsebody/EnumStatus.kt
@@ -2,12 +2,19 @@ package com.swm_standard.phote.common.responsebody
 
 import org.springframework.http.HttpStatus
 
-enum class SuccessCode(val statusCode: Int, val msg: String) {
+enum class SuccessCode(
+    val statusCode: Int,
+    val msg: String,
+) {
     SUCCESS(HttpStatus.OK.value(), "정상 처리 되었습니다."),
 }
 
-enum class ErrorCode(val statusCode: Int, val msg: String) {
+enum class ErrorCode(
+    val statusCode: Int,
+    val msg: String,
+) {
     ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "에러가 발생했습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "요청 값이 올바르지 않습니다."),
-    NOT_FOUND(HttpStatus.NOT_FOUND.value(), "요청 값을 찾을 수 없습니다.")
+    NOT_FOUND(HttpStatus.NOT_FOUND.value(), "요청 값을 찾을 수 없습니다."),
+    BAD_GATEWAY(HttpStatus.BAD_GATEWAY.value(), "서버가 요청을 처리하는데 실패했습니다."),
 }

--- a/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
@@ -5,7 +5,6 @@ import com.swm_standard.phote.dto.UserInfoResponse
 import com.swm_standard.phote.service.GoogleAuthService
 import com.swm_standard.phote.service.KaKaoAuthService
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.GetMapping

--- a/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
@@ -22,13 +22,13 @@ class QuestionController(
     private val questionService: QuestionService,
     private val s3Service: S3Service,
 ) {
-
     @Operation(summary = "createQuestion", description = "문제 생성")
     @SecurityRequirement(name = "bearer Auth")
-    @PostMapping( "/question")
-    fun createQuestion(@Parameter(hidden = true) @MemberId memberId: UUID,
-                       @Valid @RequestPart request: CreateQuestionRequest,
-                       @RequestPart image: MultipartFile?
+    @PostMapping("/question")
+    fun createQuestion(
+        @Parameter(hidden = true) @MemberId memberId: UUID,
+        @Valid @RequestPart request: CreateQuestionRequest,
+        @RequestPart image: MultipartFile?,
     ): BaseResponse<CreateQuestionResponse> {
         val imageUrl = image?.let { s3Service.uploadImage(it) }
         return BaseResponse(msg = "문제 생성 성공", data = questionService.createQuestion(memberId, request, imageUrl))
@@ -47,9 +47,11 @@ class QuestionController(
     @Operation(summary = "searchQuestions", description = "문제 검색")
     @SecurityRequirement(name = "bearer Auth")
     @GetMapping("/questions")
-    fun searchQuestions(@Parameter(hidden = true) @MemberId memberId: UUID,
-                        @RequestParam(required = false) tags: List<String>? = null,
-                        @RequestParam(required = false) keywords: List<String>? = null): BaseResponse<List<Question>> {
+    fun searchQuestions(
+        @Parameter(hidden = true) @MemberId memberId: UUID,
+        @RequestParam(required = false) tags: List<String>? = null,
+        @RequestParam(required = false) keywords: List<String>? = null,
+    ): BaseResponse<List<Question>> {
         questionService.searchQuestions(memberId, tags, keywords)
         return BaseResponse(msg = "문제 검색 성공", data = questionService.searchQuestions(memberId, tags, keywords))
     }
@@ -57,12 +59,16 @@ class QuestionController(
     @Operation(summary = "searchQuestionsToAdd", description = "문제집에 추가할 문제 검색")
     @SecurityRequirement(name = "bearer Auth")
     @GetMapping("/questions/workbook/{workbookId}")
-    fun searchQuestionsToAdd(@Parameter(hidden = true) @MemberId memberId: UUID,
-                             @PathVariable(required = true) workbookId: UUID,
-                             @RequestParam(required = false) tags: List<String>? = null,
-                             @RequestParam(required = false) keywords: List<String>? = null): BaseResponse<List<SearchQuestionsToAddResponse>> {
-        return BaseResponse(msg = "문제집에 추가할 문제 목록 검색 성공", data = questionService.searchQuestionsToAdd(memberId, workbookId, tags, keywords))
-    }
+    fun searchQuestionsToAdd(
+        @Parameter(hidden = true) @MemberId memberId: UUID,
+        @PathVariable(required = true) workbookId: UUID,
+        @RequestParam(required = false) tags: List<String>? = null,
+        @RequestParam(required = false) keywords: List<String>? = null,
+    ): BaseResponse<List<SearchQuestionsToAddResponse>> =
+        BaseResponse(
+            msg = "문제집에 추가할 문제 목록 검색 성공",
+            data = questionService.searchQuestionsToAdd(memberId, workbookId, tags, keywords),
+        )
 
     @Operation(summary = "deleteQuestion", description = "문제 삭제")
     @SecurityRequirement(name = "bearer Auth")
@@ -70,4 +76,15 @@ class QuestionController(
     fun deleteQuestion(
         @PathVariable(required = true) id: UUID,
     ): BaseResponse<DeleteQuestionResponse> = BaseResponse(msg = "문제 삭제 성공", data = questionService.deleteQuestion(id))
+
+    @PostMapping("question-transform")
+    fun transformQuestion(
+        @RequestPart image: MultipartFile?,
+    ): BaseResponse<TransformQuestionResponse> {
+        val imageUrl = image?.let { s3Service.uploadImage(it) }
+
+        val response: TransformQuestionResponse = questionService.transformQuestion(imageUrl!!)
+
+        return BaseResponse(data = response, msg = "문제 변환 성공")
+    }
 }

--- a/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
@@ -16,12 +16,16 @@ import java.util.*
 @RestController
 @RequestMapping("/api")
 @Tag(name = "Workbook", description = "Workbook API Document")
-class WorkbookController(private val workbookService: WorkbookService) {
-
+class WorkbookController(
+    private val workbookService: WorkbookService,
+) {
     @Operation(summary = "createWorkbook", description = "문제집 생성")
     @SecurityRequirement(name = "bearer Auth")
     @PostMapping("/workbook")
-    fun createWorkbook(@Valid @RequestBody request: CreateWorkbookRequest, @Parameter(hidden = true) @MemberId memberId: UUID): BaseResponse<CreateWorkbookResponse> {
+    fun createWorkbook(
+        @Valid @RequestBody request: CreateWorkbookRequest,
+        @Parameter(hidden = true) @MemberId memberId: UUID,
+    ): BaseResponse<CreateWorkbookResponse> {
         val workbook = workbookService.createWorkbook(request, memberId)
 
         return BaseResponse(msg = "문제집 생성 성공", data = workbook)
@@ -52,8 +56,9 @@ class WorkbookController(private val workbookService: WorkbookService) {
     @Operation(summary = "readWorkbookList", description = "문제집 목록 조회")
     @SecurityRequirement(name = "bearer Auth")
     @GetMapping("/workbooks")
-    fun readWorkbookList(@Parameter(hidden = true) @MemberId memberId: UUID): BaseResponse<List<ReadWorkbookListResponse>> {
-
+    fun readWorkbookList(
+        @Parameter(hidden = true) @MemberId memberId: UUID,
+    ): BaseResponse<List<ReadWorkbookListResponse>> {
         val readWorkbookList = workbookService.readWorkbookList(memberId)
 
         return BaseResponse(msg = "문제집 목록 조회 성공", data = readWorkbookList)

--- a/src/main/kotlin/com/swm_standard/phote/dto/ChatGptDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ChatGptDtos.kt
@@ -1,0 +1,54 @@
+package com.swm_standard.phote.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.swm_standard.phote.external.chatgpt.PROMPT
+
+data class RequestMessage(
+    val role: String,
+    val content: List<Any>,
+)
+
+data class ResponseMessage(
+    val role: String,
+    val content: String,
+)
+
+data class TextContent(
+    val text: String,
+    val type: String = "text",
+)
+
+data class ImageContent(
+    @JsonProperty("image_url")
+    val imageUrl: ImageInfo,
+    val type: String = "image_url",
+)
+
+data class ImageInfo(
+    val url: String,
+)
+
+data class ChatGPTRequest(
+    var model: String,
+    var messages: MutableList<RequestMessage>,
+) {
+    constructor(model: String, imageUrl: String) :
+        this(
+            model,
+            mutableListOf(
+                RequestMessage(
+                    "user",
+                    mutableListOf(TextContent(PROMPT), ImageContent(ImageInfo(imageUrl))),
+                ),
+            ),
+        )
+}
+
+data class ChatGPTResponse(
+    val choices: List<Choice>,
+)
+
+data class Choice(
+    var index: Int,
+    var message: ResponseMessage,
+)

--- a/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
@@ -66,3 +66,8 @@ data class SearchQuestionsToAddResponse(
     val memo: String? = null,
     var isContain: Boolean = false,
 )
+
+data class TransformQuestionResponse(
+    val content: String,
+    val options: List<String>,
+)

--- a/src/main/kotlin/com/swm_standard/phote/external/chatgpt/ChatGptConfig.kt
+++ b/src/main/kotlin/com/swm_standard/phote/external/chatgpt/ChatGptConfig.kt
@@ -1,0 +1,24 @@
+package com.swm_standard.phote.external.chatgpt
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestTemplate
+
+@Configuration
+class ChatGptConfig {
+    @Value("\${openai.api.key}")
+    lateinit var apiKey: String
+
+    @Bean
+    fun template(): RestTemplate {
+        val restTemplate = RestTemplate()
+
+        restTemplate.interceptors.add { request, body, execution ->
+            request.headers.add("Authorization", "Bearer $apiKey")
+            execution.execute(request, body)
+        }
+
+        return restTemplate
+    }
+}

--- a/src/main/kotlin/com/swm_standard/phote/external/chatgpt/Prompt.kt
+++ b/src/main/kotlin/com/swm_standard/phote/external/chatgpt/Prompt.kt
@@ -1,0 +1,3 @@
+package com.swm_standard.phote.external.chatgpt
+
+const val PROMPT: String = "너는 지금부터 텍스트 추출기야. 위에 첨부한 사진에서 문제 문항에 해당하는 텍스트와 객관식 문제라면 선택지 텍스트를 #로 분리해서 추출해줘. 다른 대답없이 텍스트만 보내줘"

--- a/src/main/kotlin/com/swm_standard/phote/external/swagger/SwaggerConfig.kt
+++ b/src/main/kotlin/com/swm_standard/phote/external/swagger/SwaggerConfig.kt
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.models.info.Info
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
-
 @Configuration
 @SecurityScheme(name = "bearer Auth", type = SecuritySchemeType.HTTP, bearerFormat = "JWT", scheme = "bearer")
 class SwaggerConfig {


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- ChatGPT를 이용하여 문제 사진의 텍스트를 추출하는 기능을 구현했습니다.
(두 커밋 중 6f708adad10f7870f86be01d2f51ce4efc9098cd 만 기능 구현 관련 커밋입니다!)

&nbsp;

**🙌🏻 예시 Response Body 🙌🏻**
<img width="400" alt="스크린샷 2024-07-22 오후 11 57 45" src="https://github.com/user-attachments/assets/b171850f-b7e9-444d-9a3e-4331f604d262">

- 그림 포함 문제는 아직 쫄려서 안해봤지만 텍스트만 있는 문제는 잘 추출합니다!

---

### ✨ 참고 사항

- 더 정확한 결과물을 위해 프롬프트를 신중하게 고민해봐야할 것 같습니다.
- 에러 처리는 일단 문제 문항이 비어 있을 경우만 처리했습니다. ➡️ 객관식 텍스트가 문제 문항까지 넘어온다거나 하는 시맨틱한 에러는 처리할 수가 없다는게 아쉽네요..
    -  더 처리할만한 예외가 있다면 알려주세요!
- 오늘 (7/23) 중으로 관련 내용 위키 작성 예정입니다.
- ChatGPT api 호출 시 이미지 전달을 url 형태로 해야해서 s3에 저장을 한번 하는데 **폴더로 나눠서 프로필 이미지와 구분**을 해야할 것 같습니다! 
    - 그리고 `1) 주기적으로 삭제 설정을 해두거나 2) 저장하는 김에 사용자가 원할 때 보여주도록 구현하기` 두가지가 고민해볼만한 것 같은데 어떻게 생각하시나요?
-  swagger 는 그림/도표 변환까지 다 구현한 다음에 추가하는게 좋을 것 같습니다..!

---

### ⏰ 현재 버그

x

---

### ✏ Git Close
- #84 
