### PR TITLE
Feat: S3 버킷 폴더 구분

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
@@ -2,7 +2,12 @@ package com.swm_standard.phote.controller
 
 import com.swm_standard.phote.common.resolver.memberId.MemberId
 import com.swm_standard.phote.common.responsebody.BaseResponse
-import com.swm_standard.phote.dto.*
+import com.swm_standard.phote.dto.CreateQuestionRequest
+import com.swm_standard.phote.dto.CreateQuestionResponse
+import com.swm_standard.phote.dto.DeleteQuestionResponse
+import com.swm_standard.phote.dto.ReadQuestionDetailResponse
+import com.swm_standard.phote.dto.SearchQuestionsToAddResponse
+import com.swm_standard.phote.dto.TransformQuestionResponse
 import com.swm_standard.phote.entity.Question
 import com.swm_standard.phote.external.aws.S3Service
 import com.swm_standard.phote.service.QuestionService
@@ -11,9 +16,16 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
-import java.util.*
+import java.util.UUID
 
 @RestController
 @RequestMapping("/api")
@@ -81,8 +93,7 @@ class QuestionController(
     fun transformQuestion(
         @RequestPart image: MultipartFile?,
     ): BaseResponse<TransformQuestionResponse> {
-        val imageUrl = image?.let { s3Service.uploadImage(it) }
-
+        val imageUrl = image?.let { s3Service.uploadChatGptImage(it) }
         val response: TransformQuestionResponse = questionService.transformQuestion(imageUrl!!)
 
         return BaseResponse(data = response, msg = "문제 변환 성공")


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 문제 변환에 사용되는 이미지에 수명 주기 규칙을 적용하기 위해 버킷 내에서 폴더를 구분해 저장합니다. `S3Service` 에 이를 위한 메서드를 하나 추가했습니다.
- 파라미터로 무언갈 받아서 폴더 구분을 하면 중복이 적어 더 좋을 것 같지만, 일단 지금은 충돌을 줄이기 위해 `uploadImage()` 메서드와 유사한 `uploadChatGptImage()` 메서드를 하나 만들었습니다.

---

### ✨ 참고 사항

- 위키 참고해주세요 💬 [Backend/S3 수명주기 설정](https://swm-standard.github.io/phote-wiki/s3-%EC%88%98%EB%AA%85%EC%A3%BC%EA%B8%B0-%EC%84%A4%EC%A0%95.html#py5d6k_5)

- 추가적으로 `QuestionController` 에 한해 import 문 와일드카드를 없애보았습니다.. 길어지네요..
---

### ⏰ 현재 버그

x

---

### ✏ Git Close
- #112 
