### PR TITLE
Feat: CustomAuditingEntity 구현

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/PhoteApplication.kt
+++ b/src/main/kotlin/com/swm_standard/phote/PhoteApplication.kt
@@ -2,12 +2,14 @@ package com.swm_standard.phote
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 // @EnableSentry(
 // 	dsn = "https://adee77c92dcb5df82124bef4932b8e11@o4507509663596544.ingest.us.sentry.io/4507509678145536",
 // 	exceptionResolverOrder = Ordered.LOWEST_PRECEDENCE
 // )
 @SpringBootApplication
+@EnableJpaAuditing
 class PhoteApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/swm_standard/phote/entity/Answer.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Answer.kt
@@ -19,7 +19,7 @@ data class Answer(
     @Column(name = "submitted_answer")
     private val submittedAnswer: String,
     private val isCorrect: Boolean,
-) {
+) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "answer_id")

--- a/src/main/kotlin/com/swm_standard/phote/entity/BaseTimeEntity.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/BaseTimeEntity.kt
@@ -1,0 +1,24 @@
+package com.swm_standard.phote.entity
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@EntityListeners(AuditingEntityListener::class)
+@MappedSuperclass
+abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+
+    @LastModifiedDate
+    var modifiedAt: LocalDateTime? = null
+
+    @JsonIgnore
+    val deletedAt: LocalDateTime? = null
+}

--- a/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
@@ -18,7 +18,7 @@ data class Exam(
     @ManyToOne
     @JoinColumn(name = "workbook_id")
     private val workbook: Workbook,
-) {
+) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "exam_id")

--- a/src/main/kotlin/com/swm_standard/phote/entity/Member.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Member.kt
@@ -1,9 +1,6 @@
 package com.swm_standard.phote.entity
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.*
-import org.hibernate.annotations.CreationTimestamp
-import java.time.LocalDateTime
 import java.util.UUID
 
 @Entity
@@ -13,14 +10,8 @@ data class Member(
     val image: String,
     @Enumerated(EnumType.STRING)
     val provider: Provider,
-) {
+) : BaseTimeEntity() {
     @Id
     @Column(name = "member_uuid", nullable = false, unique = true)
     val id: UUID = UUID.randomUUID()
-
-    @CreationTimestamp
-    val joinedAt: LocalDateTime = LocalDateTime.now()
-
-    @JsonIgnore
-    val deletedAt: LocalDateTime? = null
 }

--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -2,59 +2,45 @@ package com.swm_standard.phote.entity
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.JsonNode
-import jakarta.persistence.*
-import org.hibernate.annotations.CreationTimestamp
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.Lob
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import org.hibernate.type.SqlTypes
-import org.springframework.data.annotation.LastModifiedDate
-import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 
 @Entity
 @SQLDelete(sql = "UPDATE question SET deleted_at = NOW() WHERE question_uuid = ?")
 @SQLRestriction("deleted_at is NULL")
 data class Question(
-
     @Id @Column(name = "question_uuid", nullable = false, unique = true)
     val id: UUID = UUID.randomUUID(),
-
     @ManyToOne
     @JoinColumn(name = "member_id")
     @JsonIgnore
     val member: Member,
-
     @Lob
     val statement: String,
-
     @Column(columnDefinition = "json")
     @JdbcTypeCode(SqlTypes.JSON)
     val options: JsonNode? = null,
-
     val image: String?,
-
     val answer: String,
-
     @Enumerated(EnumType.STRING)
     val category: Category,
-
     @OneToMany(mappedBy = "question", cascade = [CascadeType.REMOVE])
     @JsonIgnore
     val questionSet: List<QuestionSet>? = null,
-
     @OneToMany(mappedBy = "question", cascade = [CascadeType.REMOVE])
     var tags: MutableList<Tag> = mutableListOf(),
-
     val memo: String?,
-
-    @CreationTimestamp
-    val createdAt: LocalDateTime = LocalDateTime.now(),
-
-    @JsonIgnore
-    var deletedAt: LocalDateTime? = null,
-
-    @LastModifiedDate
-    var modifiedAt: LocalDateTime? = LocalDateTime.now()
-
-)
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
@@ -1,40 +1,32 @@
 package com.swm_standard.phote.entity
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import jakarta.persistence.*
-import org.hibernate.annotations.CreationTimestamp
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
-import java.time.LocalDateTime
 import java.util.UUID
 
 @Entity
 @SQLDelete(sql = "UPDATE question_set SET deleted_at = NOW() WHERE question_set_id = ?")
 @SQLRestriction("deleted_at is NULL")
 data class QuestionSet(
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id")
     val question: Question,
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "workbook_id")
     @JsonIgnore
     val workbook: Workbook,
-
-    var sequence: Int = 0
-
-) {
-
+    var sequence: Int = 0,
+) : BaseTimeEntity() {
     @Id
     @Column(name = "question_set_id", nullable = false, unique = true)
     val id: UUID = UUID.randomUUID()
-
-    @CreationTimestamp
-    val createdAt: LocalDateTime = LocalDateTime.now()
-
-    @JsonIgnore
-    var deletedAt: LocalDateTime? = null
 
     fun updateSequence(seq: Int) {
         this.sequence = seq

--- a/src/main/kotlin/com/swm_standard/phote/entity/Tag.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Tag.kt
@@ -1,10 +1,15 @@
 package com.swm_standard.phote.entity
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
-import java.time.LocalDateTime
 
 @Entity
 @SQLDelete(sql = "UPDATE tag SET deleted_at = NOW() WHERE tag_id = ?")
@@ -14,14 +19,9 @@ data class Tag(
     @Column(name = "tag_id", unique = true)
     @JsonIgnore
     val id: Long = 0L,
-
     val name: String,
-
     @JoinColumn(name = "question_id")
     @ManyToOne
     @JsonIgnore
     var question: Question,
-
-    @JsonIgnore
-    val deletedAt: LocalDateTime? = null
-)
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
@@ -1,14 +1,19 @@
 package com.swm_standard.phote.entity
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import jakarta.persistence.*
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
 import org.hibernate.annotations.ColumnDefault
-import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
-import org.springframework.data.annotation.LastModifiedDate
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 
 @Entity
 @SQLDelete(sql = "UPDATE workbook SET deleted_at = NOW() WHERE workbook_uuid = ?")
@@ -20,7 +25,7 @@ data class Workbook(
     @JoinColumn(name = "member_id")
     @JsonIgnore
     val member: Member,
-) {
+) : BaseTimeEntity() {
     @Id
     @Column(name = "workbook_uuid", nullable = false, unique = true)
     val id: UUID = UUID.randomUUID()
@@ -33,15 +38,6 @@ data class Workbook(
 
     @ColumnDefault(value = "0")
     var quantity: Int = 0
-
-    @CreationTimestamp
-    val createdAt: LocalDateTime = LocalDateTime.now()
-
-    @JsonIgnore
-    var deletedAt: LocalDateTime? = null
-
-    @LastModifiedDate
-    var modifiedAt: LocalDateTime? = LocalDateTime.now()
 
     fun decreaseQuantity() {
         this.quantity -= 1

--- a/src/main/kotlin/com/swm_standard/phote/external/chatgpt/Prompt.kt
+++ b/src/main/kotlin/com/swm_standard/phote/external/chatgpt/Prompt.kt
@@ -1,3 +1,5 @@
 package com.swm_standard.phote.external.chatgpt
 
-const val PROMPT: String = "너는 지금부터 텍스트 추출기야. 위에 첨부한 사진에서 문제 문항에 해당하는 텍스트와 객관식 문제라면 선택지 텍스트를 #로 분리해서 추출해줘. 다른 대답없이 텍스트만 보내줘"
+const val PROMPT: String =
+    "너는 지금부터 텍스트 추출기야. 위에 첨부한 사진에서 문제 문항에 해당하는 텍스트와" +
+        "객관식 문제라면 선택지 텍스트를 #로 분리해서 추출해줘. 다른 대답없이 텍스트만 보내줘"

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepositoryImpl.kt
@@ -11,36 +11,43 @@ import java.util.UUID
 
 @Repository
 class QuestionCustomRepositoryImpl(
-    private val jpaQueryFactory: JPAQueryFactory
+    private val jpaQueryFactory: JPAQueryFactory,
 ) : QuestionCustomRepository {
-
-    override fun searchQuestionsList(memberId: UUID, tags: List<String>?, keywords: List<String>?): List<Question> {
+    override fun searchQuestionsList(
+        memberId: UUID,
+        tags: List<String>?,
+        keywords: List<String>?,
+    ): List<Question> {
         val question = QQuestion.question
         val tag = QTag.tag
 
-        val query = jpaQueryFactory
-            .selectFrom(question)
-            .where(question.member.id.eq(memberId))
-            .leftJoin(question.tags, tag).fetchJoin()
-            .distinct()
+        val query =
+            jpaQueryFactory
+                .selectFrom(question)
+                .where(question.member.id.eq(memberId))
+                .leftJoin(question.tags, tag)
+                .fetchJoin()
+                .distinct()
 
         // 태그 조건: tags로 들어온 태그들을 모두 포함하는 문제 검색
         if (!tags.isNullOrEmpty()) {
-            val tagCondition = tags.map { tagName ->
-                jpaQueryFactory
-                    .selectFrom(tag)
-                    .where(tag.name.eq(tagName).and(tag.question.eq(question)))
-                    .exists()
-            }
+            val tagCondition =
+                tags.map { tagName ->
+                    jpaQueryFactory
+                        .selectFrom(tag)
+                        .where(tag.name.eq(tagName).and(tag.question.eq(question)))
+                        .exists()
+                }
             // reduce: 서브쿼리(sub)들을 and조건으로 결합
             query.where(tagCondition.reduce { sub, predicate -> sub.and(predicate) })
         }
 
         // 문항 조건: keywords로 들어온 검색어를 모두 포함하는 문항(statement)을 가진 문제 검색
         if (!keywords.isNullOrEmpty()) {
-            val keywordConditions = keywords.map { keyword ->
-                question.statement.contains(keyword)
-            }
+            val keywordConditions =
+                keywords.map { keyword ->
+                    question.statement.contains(keyword)
+                }
             query.where(keywordConditions.reduce { acc, predicate -> acc.and(predicate) })
         }
 
@@ -53,16 +60,16 @@ class QuestionCustomRepositoryImpl(
         memberId: UUID,
         workbookId: UUID,
         tags: List<String>?,
-        keywords: List<String>?
+        keywords: List<String>?,
     ): List<SearchQuestionsToAddResponse> {
-
         val questionSet = QQuestionSet.questionSet
 
-        val questionsInWorkbook = jpaQueryFactory
-            .select(questionSet.question.id)
-            .from(questionSet)
-            .where(questionSet.workbook.id.eq(workbookId))
-            .fetch()
+        val questionsInWorkbook =
+            jpaQueryFactory
+                .select(questionSet.question.id)
+                .from(questionSet)
+                .where(questionSet.workbook.id.eq(workbookId))
+                .fetch()
 
         val questions = searchQuestionsList(memberId, tags, keywords)
 
@@ -77,7 +84,7 @@ class QuestionCustomRepositoryImpl(
                 category = question.category,
                 tags = question.tags,
                 memo = question.memo,
-                isContain = question.id in questionsInWorkbook
+                isContain = question.id in questionsInWorkbook,
             )
         }
     }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- BaseTimeEntity 를 구축하여 엔티티 공용으로 사용하는 JpaAuditing 필드들을 따로 뺐습니다.
- 2db5f212f739149a270f3b0ba9e385dadd29933c 커밋 위주로 확인해주시면 됩니다.

---

### ✨ 참고 사항

- 충격 사건 이때까지 `@EnableJpaAuditing` 을 추가해놓지 않았었네요.. 아마 제대로 실행안됐을 듯 합니다..
- 이제 정상 작동할거라 수동으로 `LocalDateTime.now()` 넣었던 부분들 리팩토링 때 빼면 될 듯합니다.
- Entity Class 위주로 import 문 와일드카드 삭제했습니다.

- 수정이 없는 테이블에도 불필요하게 `modifiedAt` 필드가 들어가긴하는데 해결하는게 좋을까요?

<img width="500" alt="스크린샷 2024-07-26 오후 3 22 11" src="https://github.com/user-attachments/assets/aabb238e-8b50-4e2b-bbaa-cc8e227fffb2">



---

### ⏰ 현재 버그

x

---

### ✏ Git Close
- #119 