### PR TITLE
Refactor: Question 관련 코드 리팩토링

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -100,7 +100,6 @@ class QuestionService(
         question.questionSet?.map {
             val workbook = it.workbook
             workbook.decreaseQuantity()
-            workbookRepository.save(workbook)
         }
 
         questionRepository.deleteById(id)

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -15,7 +15,6 @@ import com.swm_standard.phote.entity.Tag
 import com.swm_standard.phote.repository.MemberRepository
 import com.swm_standard.phote.repository.QuestionRepository
 import com.swm_standard.phote.repository.TagRepository
-import com.swm_standard.phote.repository.WorkbookRepository
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,7 +27,6 @@ class QuestionService(
     private val questionRepository: QuestionRepository,
     private val memberRepository: MemberRepository,
     private val tagRepository: TagRepository,
-    private val workbookRepository: WorkbookRepository,
     private val template: RestTemplate,
 ) {
     @Value("\${openai.model}")

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -2,7 +2,14 @@ package com.swm_standard.phote.service
 
 import com.swm_standard.phote.common.exception.ChatGptErrorException
 import com.swm_standard.phote.common.exception.NotFoundException
-import com.swm_standard.phote.dto.*
+import com.swm_standard.phote.dto.CreateQuestionRequest
+import com.swm_standard.phote.dto.CreateQuestionResponse
+import com.swm_standard.phote.dto.ReadQuestionDetailResponse
+import com.swm_standard.phote.dto.SearchQuestionsToAddResponse
+import com.swm_standard.phote.dto.DeleteQuestionResponse
+import com.swm_standard.phote.dto.TransformQuestionResponse
+import com.swm_standard.phote.dto.ChatGPTRequest
+import com.swm_standard.phote.dto.ChatGPTResponse
 import com.swm_standard.phote.entity.Question
 import com.swm_standard.phote.entity.Tag
 import com.swm_standard.phote.repository.MemberRepository
@@ -54,7 +61,7 @@ class QuestionService(
             )
 
         // 태그 생성
-        request.tags?.forEach {
+        request.tags?.map {
             tagRepository.save(Tag(name = it, question = question))
         }
 
@@ -73,12 +80,7 @@ class QuestionService(
         memberId: UUID,
         tags: List<String>?,
         keywords: List<String>?,
-    ): List<Question> {
-        // 요청을 보낸 멤버가 생성한 문제이고, tags, keywords를 모두 포함하는 문제만 불러옴
-        val questions: List<Question> = questionRepository.searchQuestionsList(memberId, tags, keywords)
-
-        return questions
-    }
+    ): List<Question> = questionRepository.searchQuestionsList(memberId, tags, keywords)
 
     @Transactional(readOnly = true)
     fun searchQuestionsToAdd(
@@ -86,12 +88,8 @@ class QuestionService(
         workbookId: UUID,
         tags: List<String>?,
         keywords: List<String>?,
-    ): List<SearchQuestionsToAddResponse> {
-        val questions: List<SearchQuestionsToAddResponse> =
-            questionRepository.searchQuestionsToAddList(memberId, workbookId, tags, keywords)
-
-        return questions
-    }
+    ): List<SearchQuestionsToAddResponse> =
+        questionRepository.searchQuestionsToAddList(memberId, workbookId, tags, keywords)
 
     @Transactional
     fun deleteQuestion(id: UUID): DeleteQuestionResponse {
@@ -99,8 +97,8 @@ class QuestionService(
         val question = questionRepository.findById(id).orElseThrow { NotFoundException("questionId", "존재하지 않는 UUID") }
 
         // 연결된 workbook의 quantity 감소
-        question.questionSet?.forEach { questionSet ->
-            val workbook = questionSet.workbook
+        question.questionSet?.map {
+            val workbook = it.workbook
             workbook.decreaseQuantity()
             workbookRepository.save(workbook)
         }

--- a/src/test/kotlin/com/swm_standard/phote/entity/QuestionRepositoryTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/QuestionRepositoryTest.kt
@@ -1,0 +1,36 @@
+package com.swm_standard.phote.entity
+
+import com.swm_standard.phote.repository.QuestionRepository
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+import kotlin.test.assertEquals
+
+@SpringBootTest
+@Transactional
+class QuestionRepositoryTest {
+    @Mock
+    private lateinit var questionRepository: QuestionRepository
+
+    @Test
+    fun `문제를 생성한다`() {
+        // given
+        val question = Question(
+            member = Member("phote", "phote@test.com", "imageUrl", Provider.KAKAO),
+            statement = "모든 각이 동일한 삼각형은?",
+            image = "http://example.com/image.jpg",
+            answer = "정삼각형",
+            category = Category.ESSAY,
+            memo = "삼각형 내각의 합은 180도이다."
+        )
+
+        // when
+        Mockito.`when`(questionRepository.save(question)).thenReturn(question)
+        val savedQuestion = questionRepository.save(question)
+
+        // then
+        assertEquals(savedQuestion.id, question.id)
+    }
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- question service 리팩토링
  - import 문 와일드카드 삭제
  - forEach -> map 변경(굳이..? 싶긴 한데 가독성이 그나마 나은 것 같아서..)
  - deleteQuestion 후 불필요한 save문 삭제
- questionRepositoryTest 작성

---

### ✨ 참고 사항
- 진짜 도저히 question단에 비즈니스 로직으로 분리할게 없어서 일단 시험삼아 createQuestion이라도 테스트코드 작성해봤읍니다....
---

### ⏰ 현재 버그

---

### ✏ Git Close #122 
