### PR TITLE
Refactor: Workbook 관련 코드 리팩토링

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
@@ -31,4 +31,12 @@ data class QuestionSet(
     fun updateSequence(seq: Int) {
         this.sequence = seq
     }
+
+    companion object {
+        fun createSequence(
+            question: Question,
+            workbook: Workbook,
+            nextSequence: Int,
+        ) = QuestionSet(question, workbook, nextSequence)
+    }
 }

--- a/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
@@ -25,6 +25,7 @@ data class Workbook(
     @JoinColumn(name = "member_id")
     @JsonIgnore
     val member: Member,
+    var emoji: String,
 ) : BaseTimeEntity() {
     @Id
     @Column(name = "workbook_uuid", nullable = false, unique = true)
@@ -34,10 +35,34 @@ data class Workbook(
     @OrderBy("sequence asc")
     val questionSet: List<QuestionSet>? = null
 
-    var emoji: String = "📚"
-
     @ColumnDefault(value = "0")
     var quantity: Int = 0
+
+    companion object {
+        fun createWorkbook(
+            title: String,
+            description: String?,
+            member: Member,
+        ) = Workbook(
+            title,
+            description,
+            member,
+            matchEmojiByTitle(title),
+        )
+
+        private fun matchEmojiByTitle(title: String): String {
+            val math: List<String> = listOf("수학", "math", "미적분", "확통", "수1", "수2", "기하", "대수")
+            val language: List<String> = listOf("국어", "언매", "화작", "비문학", "문학", "독서", "듣기", "영어", "eng", "토익", "외국")
+            val science: List<String> = listOf("과학", "화학", "생물", "생명", "물리", "지구")
+
+            return when {
+                math.size != math.filter { !title.contains(it) }.size -> "➗"
+                language.size != language.filter { !title.contains(it) }.size -> "💬"
+                science.size != science.filter { !title.contains(it) }.size -> "🧪"
+                else -> "📚"
+            }
+        }
+    }
 
     fun decreaseQuantity() {
         this.quantity -= 1
@@ -51,17 +76,12 @@ data class Workbook(
 
     fun compareQuestionQuantity(num: Int) = num == this.quantity
 
-    fun matchEmojiByTitle() {
-        val math: List<String> = listOf("수학", "math", "미적분", "확통", "수1", "수2", "기하", "대수")
-        val language: List<String> = listOf("국어", "언매", "화작", "비문학", "문학", "독서", "듣기", "영어", "eng", "토익", "외국")
-        val science: List<String> = listOf("과학", "화학", "생물", "생명", "물리", "지구")
-
-        emoji =
-            when {
-                math.size != math.filter { !title.contains(it) }.size -> "➗"
-                language.size != language.filter { !title.contains(it) }.size -> "💬"
-                science.size != science.filter { !title.contains(it) }.size -> "🧪"
-                else -> "📚"
-            }
+    fun updateWorkbook(
+        title: String,
+        description: String?,
+    ) {
+        this.title = title
+        this.description = description
+        this.emoji = matchEmojiByTitle(title)
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetRepository.kt
@@ -2,12 +2,20 @@ package com.swm_standard.phote.repository
 
 import com.swm_standard.phote.entity.QuestionSet
 import org.springframework.data.jpa.repository.JpaRepository
-
 import java.util.UUID
 
-interface QuestionSetRepository : JpaRepository<QuestionSet, UUID>, QuestionSetCustomRepository {
+interface QuestionSetRepository :
+    JpaRepository<QuestionSet, UUID>,
+    QuestionSetCustomRepository {
+    fun findByQuestionIdAndWorkbookId(
+        questionId: UUID,
+        workbookId: UUID,
+    ): QuestionSet?
 
-    fun findByQuestionIdAndWorkbookId(questionId: UUID, workbookId: UUID): QuestionSet?
+    fun existsByQuestionIdAndWorkbookId(
+        questionId: UUID,
+        workbookId: UUID,
+    ): Boolean
 
     fun findByWorkbookIdOrderBySequence(workbookId: UUID): List<QuestionSet>
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 import java.util.UUID
+import kotlin.jvm.optionals.getOrElse
 
 @Service
 class WorkbookService(
@@ -54,7 +55,7 @@ class WorkbookService(
 
     @Transactional(readOnly = true)
     fun readWorkbookDetail(id: UUID): ReadWorkbookDetailResponse {
-        val workbook = workbookRepository.findById(id).orElseThrow { NotFoundException() }
+        val workbook = workbookRepository.findById(id).getOrElse { throw NotFoundException() }
 
         return ReadWorkbookDetailResponse(
             workbook.id,
@@ -68,7 +69,7 @@ class WorkbookService(
 
     @Transactional(readOnly = true)
     fun readWorkbookList(memberId: UUID): List<ReadWorkbookListResponse> {
-        val member = memberRepository.findById(memberId).orElseThrow { InvalidInputException("memberId") }
+        val member = memberRepository.findById(memberId).getOrElse { throw InvalidInputException("memberId") }
         val workbooks: List<Workbook> = workbookRepository.findAllByMember(member)
 
         return workbooks.map { workbook ->
@@ -98,7 +99,7 @@ class WorkbookService(
             val question: Question =
                 questionRepository
                     .findById(questionId)
-                    .orElseThrow { NotFoundException(fieldName = "question", message = "id 를 재확인해주세요.") }
+                    .getOrElse { throw NotFoundException(fieldName = "question", message = "id 를 재확인해주세요.") }
 
             if (questionSetRepository
                     .existsByQuestionIdAndWorkbookId(questionId, workbook.id)
@@ -121,7 +122,7 @@ class WorkbookService(
         val workbook =
             workbookRepository
                 .findById(workbookId)
-                .orElseThrow { NotFoundException(fieldName = "workbook", message = "id 를 재확인해주세요.") }
+                .getOrElse { throw NotFoundException(fieldName = "workbook", message = "id 를 재확인해주세요.") }
 
         questionSetRepository.findByQuestionIdAndWorkbookId(questionId, workbookId)?.also {
             questionSetRepository.delete(it)
@@ -142,7 +143,7 @@ class WorkbookService(
         val workbook: Workbook =
             workbookRepository
                 .findById(workbookId)
-                .orElseThrow { NotFoundException(fieldName = "workbook", message = "id를 재확인해주세요.") }
+                .getOrElse { throw NotFoundException(fieldName = "workbook", message = "id를 재확인해주세요.") }
 
         // 질문 : 이런 로직도 비지니스 함수 내부로 넣어야할지
         if (!workbook.compareQuestionQuantity(request.size)) {
@@ -155,7 +156,7 @@ class WorkbookService(
         request.forEach {
             questionSetRepository
                 .findById(it.id)
-                .orElseThrow { InvalidInputException("questionSet") }
+                .getOrElse { throw InvalidInputException("questionSet") }
                 .apply {
                     updateSequence(it.sequence)
                 }
@@ -172,7 +173,7 @@ class WorkbookService(
         val workbook: Workbook =
             workbookRepository
                 .findById(workbookId)
-                .orElseThrow { NotFoundException(fieldName = "workbook", message = "id를 재확인해주세요.") }
+                .getOrElse { throw NotFoundException(fieldName = "workbook", message = "id를 재확인해주세요.") }
 
         workbook.updateWorkbook(request.title, request.description)
 
@@ -182,7 +183,7 @@ class WorkbookService(
     fun readQuestionsInWorkbook(workbookId: UUID): List<ReadQuestionsInWorkbookResponse> {
         workbookRepository
             .findById(workbookId)
-            .orElseThrow { InvalidInputException(fieldName = "workbook", message = "id를 재확인해주세요.") }
+            .getOrElse { throw InvalidInputException(fieldName = "workbook", message = "id를 재확인해주세요.") }
         val questionSets: List<QuestionSet> = questionSetRepository.findByWorkbookIdOrderBySequence(workbookId)
 
         return questionSets.map { set ->

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -40,7 +40,11 @@ class WorkbookService(
         memberId: UUID,
     ): CreateWorkbookResponse {
         val member = memberRepository.findById(memberId).orElseThrow { NotFoundException(fieldName = "member") }
-        val workbook = Workbook.createWorkbook(request.title, request.description, member)
+        val workbook: Workbook =
+            Workbook.createWorkbook(request.title, request.description, member).let {
+                workbookRepository.save(it)
+            }
+
         return CreateWorkbookResponse(workbook.id)
     }
 

--- a/src/test/kotlin/com/swm_standard/phote/entity/WorkbookTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/WorkbookTest.kt
@@ -6,6 +6,30 @@ import java.time.LocalDateTime
 
 class WorkbookTest {
     @Test
+    fun `문제집을 생성한다`() {
+        val member: Member = createmember()
+        val testTitle = "테스트 제목 수학"
+
+        val workbook: Workbook = Workbook.createWorkbook(title = testTitle, description = "", member = member)
+
+        Assertions.assertThat(workbook.title).isEqualTo(testTitle)
+        Assertions.assertThat(workbook.emoji).isEqualTo("➗")
+    }
+
+    @Test
+    fun `문제집 정보를 수정한다`() {
+        val workbook: Workbook = createWorkbook()
+        val modifiedTitle = "수정 제목 english"
+        val modifiedDescription = "수정 설명"
+
+        workbook.updateWorkbook(modifiedTitle, modifiedDescription)
+
+        Assertions.assertThat(workbook.title).isEqualTo(modifiedTitle)
+        Assertions.assertThat(workbook.description).isEqualTo(modifiedDescription)
+        Assertions.assertThat(workbook.emoji).isEqualTo("💬")
+    }
+
+    @Test
     fun `문제 1개 삭제 시에 quantity가 1만큼 줄어든다`() {
         val workbook: Workbook = createWorkbook()
         val testNum: Int = 10
@@ -32,14 +56,28 @@ class WorkbookTest {
 
     fun createWorkbook(): Workbook =
         Workbook(
-            title = "deserunt",
+            title = "hinc",
             description = null,
-            member =
-            Member(
-                name = "Kaitlin Kinney",
-                email = "wallace.stark@example.com",
-                image = "auctor",
-                provider = Provider.APPLE,
-            ),
+            member = createmember(),
+            emoji = "📚",
         )
+
+    fun createmember(): Member =
+        Member(
+            name = "Mayra Payne",
+            email = "penelope.mccarty@example.com",
+            image = "dicant",
+            provider = Provider.APPLE,
+        )
+
+    @Test
+    fun `문제집의 문제 개수와 변수로 들어오는 정수를 비교한다`() {
+        val workbook: Workbook = createWorkbook()
+        val quantity = 2
+        workbook.quantity = quantity
+
+        val compareQuestionQuantity: Boolean = workbook.compareQuestionQuantity(quantity)
+
+        Assertions.assertThat(compareQuestionQuantity).isTrue()
+    }
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- Workbook 도메인 관련 코드들 리팩토링 진행했습니다.
- 비즈니스 로직 분리했습니다.
- 존재 여부만 확인하며 되는 부분은 레포지토리에서 `findBy~` 대신 `existsBy~` 로 변경했습니다.
- `orElseThrow` -> `getOrElse` 변경했습니다. (어떤 차이인지는 아직 감이 안오네용)
- workbook 생성 로직을 팩토리 메소드로 빼면서 생성 부분이 조금 달라져서 test 코드의 `createWorkbook` 메서드도 살짝 변경했습니다.

---

### ✨ 참고 사항

- `updateWorkbook` 테스트 코드 작성하면서 바뀐 제목에 따라 이모지가 변경되지 않는 오류를 미연에 방지할 수 있었습니다 테스트 코드 짱 😵‍💫😵‍💫

---

### ⏰ 현재 버그

- `RestTemplate -> RestClient` 변경은 둘의 차이점을 조금 더 알아보고 리팩토링 해보려고 합니다!

---

### ✏ Git Close
- #120 
