### PR TITLE
Fix: options 반환 타입 변경

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
@@ -7,8 +7,8 @@ import com.swm_standard.phote.dto.CreateQuestionResponse
 import com.swm_standard.phote.dto.DeleteQuestionResponse
 import com.swm_standard.phote.dto.ReadQuestionDetailResponse
 import com.swm_standard.phote.dto.SearchQuestionsToAddResponse
+import com.swm_standard.phote.dto.SearchQuestionsResponse
 import com.swm_standard.phote.dto.TransformQuestionResponse
-import com.swm_standard.phote.entity.Question
 import com.swm_standard.phote.external.aws.S3Service
 import com.swm_standard.phote.service.QuestionService
 import io.swagger.v3.oas.annotations.Operation
@@ -63,7 +63,7 @@ class QuestionController(
         @Parameter(hidden = true) @MemberId memberId: UUID,
         @RequestParam(required = false) tags: List<String>? = null,
         @RequestParam(required = false) keywords: List<String>? = null,
-    ): BaseResponse<List<Question>> {
+    ): BaseResponse<List<SearchQuestionsResponse>> {
         questionService.searchQuestions(memberId, tags, keywords)
         return BaseResponse(msg = "문제 검색 성공", data = questionService.searchQuestions(memberId, tags, keywords))
     }

--- a/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
@@ -14,18 +14,18 @@ data class ReadQuestionDetailResponse(
     val modifiedAt: LocalDateTime? = null,
     val statement: String,
     val image: String? = null,
-    val options: JsonNode? = null,
+    val options: List<String>? = null,
     val answer: String,
     val category: Category,
     val tags: List<Tag>? = null,
     val memo: String? = null,
 ) {
-    constructor(question: Question) : this(
+    constructor(question: Question, options: List<String>?) : this(
         createdAt = question.createdAt,
         modifiedAt = question.modifiedAt,
         statement = question.statement,
         image = question.image,
-        options = question.options,
+        options = options,
         answer = question.answer,
         tags = question.tags,
         category = question.category,
@@ -54,12 +54,38 @@ data class CreateQuestionResponse(
     val id: UUID,
 )
 
+data class SearchQuestionsResponse(
+    val id: UUID,
+    val statement: String,
+    val options: List<String>? = null,
+    val image: String? = null,
+    val answer: String? = null,
+    val category: Category,
+    val tags: List<Tag>? = null,
+    val memo: String? = null,
+    val createdAt: LocalDateTime,
+    val modifiedAt: LocalDateTime? = null,
+) {
+    constructor(question: Question, options: List<String>?) : this(
+        id = question.id,
+        statement = question.statement,
+        options = options,
+        image = question.image,
+        answer = question.answer,
+        category = question.category,
+        tags = question.tags,
+        memo = question.memo,
+        createdAt = question.createdAt,
+        modifiedAt = question.modifiedAt
+    )
+}
+
 data class SearchQuestionsToAddResponse(
     val createdAt: LocalDateTime,
     val modifiedAt: LocalDateTime? = null,
     val statement: String,
     val image: String? = null,
-    val options: JsonNode? = null,
+    val options: List<String>? = null,
     val answer: String,
     val category: Category,
     val tags: List<Tag>? = null,

--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -43,4 +43,14 @@ data class Question(
     @OneToMany(mappedBy = "question", cascade = [CascadeType.REMOVE])
     var tags: MutableList<Tag> = mutableListOf(),
     val memo: String?,
-) : BaseTimeEntity()
+) : BaseTimeEntity() {
+
+    fun deserializeOptions(): MutableList<String> {
+        val optionsList = mutableListOf<String>()
+        options!!.fields().forEach { option ->
+            optionsList.add(option.value.asText())
+        }
+
+        return optionsList
+    }
+}

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionCustomRepositoryImpl.kt
@@ -74,12 +74,13 @@ class QuestionCustomRepositoryImpl(
         val questions = searchQuestionsList(memberId, tags, keywords)
 
         return questions.map { question ->
+            val options = question.options?.let { question.deserializeOptions() }
             SearchQuestionsToAddResponse(
                 createdAt = question.createdAt,
                 modifiedAt = question.modifiedAt,
                 statement = question.statement,
                 image = question.image,
-                options = question.options,
+                options = options,
                 answer = question.answer,
                 category = question.category,
                 tags = question.tags,

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -8,6 +8,7 @@ import com.swm_standard.phote.dto.ReadQuestionDetailResponse
 import com.swm_standard.phote.dto.SearchQuestionsToAddResponse
 import com.swm_standard.phote.dto.DeleteQuestionResponse
 import com.swm_standard.phote.dto.TransformQuestionResponse
+import com.swm_standard.phote.dto.SearchQuestionsResponse
 import com.swm_standard.phote.dto.ChatGPTRequest
 import com.swm_standard.phote.dto.ChatGPTResponse
 import com.swm_standard.phote.entity.Question
@@ -69,8 +70,8 @@ class QuestionService(
     @Transactional(readOnly = true)
     fun readQuestionDetail(id: UUID): ReadQuestionDetailResponse {
         val question = questionRepository.findById(id).orElseThrow { NotFoundException("questionId", "존재하지 않는 UUID") }
-
-        return ReadQuestionDetailResponse(question)
+        val options = question.options?.let { question.deserializeOptions() }
+        return ReadQuestionDetailResponse(question, options)
     }
 
     @Transactional(readOnly = true)
@@ -78,7 +79,12 @@ class QuestionService(
         memberId: UUID,
         tags: List<String>?,
         keywords: List<String>?,
-    ): List<Question> = questionRepository.searchQuestionsList(memberId, tags, keywords)
+    ): List<SearchQuestionsResponse> {
+        return questionRepository.searchQuestionsList(memberId, tags, keywords).map { question ->
+            val options = question.options?.let { question.deserializeOptions() }
+            SearchQuestionsResponse(question, options)
+        }
+    }
 
     @Transactional(readOnly = true)
     fun searchQuestionsToAdd(

--- a/src/test/kotlin/com/swm_standard/phote/entity/QuestionTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/QuestionTest.kt
@@ -1,0 +1,46 @@
+package com.swm_standard.phote.entity
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class QuestionTest {
+
+    private fun createQuestion(): Question {
+        val objectMapper = ObjectMapper()
+        val jsonString = """
+        {
+            "1": "삼각형",
+            "2": "사각형",
+            "3": "마름모",
+            "4": "평행사변형",
+            "5": "원"
+        }
+        """
+        val options: JsonNode = objectMapper.readTree(jsonString)
+
+        return Question(
+            member = Member("phote", "phote@test.com", "imageUrl", Provider.KAKAO),
+            statement = "꼭짓점이 3개인 도형은?",
+            image = "http://example.com/image.jpg",
+            options = options,
+            answer = "1",
+            category = Category.MULTIPLE,
+            memo = "삼각형은 꼭짓점이 3개다"
+        )
+    }
+
+    @Test
+    fun `options를 역직렬화 한다`() {
+        // given
+        val question = createQuestion()
+
+        // when
+        val deserializedOptions = question.deserializeOptions()
+
+        // then
+        val expectedList = listOf("삼각형", "사각형", "마름모", "평행사변형", "원")
+        assertEquals(expectedList, deserializedOptions)
+    }
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- searchQuestionsToAdd, readQuestionDetail, searchQuestions api의 반환값인 options(선택지)의 반환 타입을 JsonNode에서 List<String>으로 변경했습니다. 노션 명세서도 변경해두었으니 예상 결과는 명세서를 참고해주세요.
- 드디어 비즈니스 로직! 테스트코드!

---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close #133 
