### PR TITLE
Feat: ReadExamHistoryDetail 구현

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
@@ -1,0 +1,29 @@
+package com.swm_standard.phote.controller
+
+import com.swm_standard.phote.common.responsebody.BaseResponse
+import com.swm_standard.phote.dto.ReadExamHistoryDetailResponse
+import com.swm_standard.phote.service.ExamService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+
+@RestController
+@RequestMapping("/api")
+@Tag(name = "Exam", description = "Exam API Document")
+class ExamController(
+    private val examService: ExamService
+) {
+    @Operation(summary = "readExamHistoryDetail", description = "문제풀이 기록 상세조회")
+    @SecurityRequirement(name = "bearer Auth")
+    @GetMapping("/exam/{id}")
+    fun readExamHistoryDetail(
+        @PathVariable(
+            required = true
+        ) id: Long
+    ): BaseResponse<ReadExamHistoryDetailResponse> =
+        BaseResponse(msg = "문제풀이 기록 상세조회 성공", data = examService.readExamHistoryDetail(id))
+}

--- a/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import java.util.UUID
 
 @RestController
 @RequestMapping("/api")
@@ -23,7 +24,7 @@ class ExamController(
     fun readExamHistoryDetail(
         @PathVariable(
             required = true
-        ) id: Long
+        ) id: UUID
     ): BaseResponse<ReadExamHistoryDetailResponse> =
         BaseResponse(msg = "문제풀이 기록 상세조회 성공", data = examService.readExamHistoryDetail(id))
 }

--- a/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
@@ -1,0 +1,21 @@
+package com.swm_standard.phote.dto
+
+import com.swm_standard.phote.entity.Category
+
+data class ReadExamHistoryDetail(
+    val statement: String,
+    val options: List<String>?,
+    val image: String?,
+    val category: Category,
+    val answer: String,
+    val submittedAnswer: String,
+    val isCorrect: Boolean,
+    val sequence: Int
+)
+
+data class ReadExamHistoryDetailResponse(
+    val id: Long,
+    val totalCorrect: Int,
+    val time: Int,
+    val questions: List<ReadExamHistoryDetail>
+)

--- a/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
@@ -1,6 +1,7 @@
 package com.swm_standard.phote.dto
 
 import com.swm_standard.phote.entity.Category
+import java.util.UUID
 
 data class ReadExamHistoryDetail(
     val statement: String,
@@ -14,7 +15,7 @@ data class ReadExamHistoryDetail(
 )
 
 data class ReadExamHistoryDetailResponse(
-    val id: Long,
+    val id: UUID,
     val totalCorrect: Int,
     val time: Int,
     val questions: List<ReadExamHistoryDetail>

--- a/src/main/kotlin/com/swm_standard/phote/entity/Answer.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Answer.kt
@@ -12,13 +12,13 @@ import jakarta.persistence.ManyToOne
 data class Answer(
     @ManyToOne
     @JoinColumn(name = "question_id")
-    private val question: Question,
+    val question: Question,
     @ManyToOne
     @JoinColumn(name = "exam_id")
-    private val exam: Exam,
+    val exam: Exam,
     @Column(name = "submitted_answer")
-    private val submittedAnswer: String,
-    private val isCorrect: Boolean,
+    val submittedAnswer: String,
+    val isCorrect: Boolean,
 ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
@@ -3,12 +3,11 @@ package com.swm_standard.phote.entity
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
+import java.util.UUID
 
 @Entity
 data class Exam(
@@ -20,9 +19,8 @@ data class Exam(
     val workbook: Workbook,
 ) : BaseTimeEntity() {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "exam_id")
-    val id: Long = 0
+    @Column(name = "exam_id", nullable = false, unique = true)
+    val id: UUID = UUID.randomUUID()
 
     val totalCorrect: Int = 0
 

--- a/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
@@ -14,10 +14,10 @@ import jakarta.persistence.OneToMany
 data class Exam(
     @ManyToOne
     @JoinColumn(name = "member_id")
-    private val member: Member,
+    val member: Member,
     @ManyToOne
     @JoinColumn(name = "workbook_id")
-    private val workbook: Workbook,
+    val workbook: Workbook,
 ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,4 +28,8 @@ data class Exam(
 
     @OneToMany(mappedBy = "exam", cascade = [(CascadeType.REMOVE)])
     val answers: MutableList<Answer> = mutableListOf()
+
+    val time: Int = 0
+
+    val sequence: Int = 0
 }

--- a/src/main/kotlin/com/swm_standard/phote/repository/ExamRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/ExamRepository.kt
@@ -2,5 +2,6 @@ package com.swm_standard.phote.repository
 
 import com.swm_standard.phote.entity.Exam
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
 
-interface ExamRepository : JpaRepository<Exam, Long>
+interface ExamRepository : JpaRepository<Exam, UUID>

--- a/src/main/kotlin/com/swm_standard/phote/repository/ExamRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/ExamRepository.kt
@@ -1,0 +1,8 @@
+package com.swm_standard.phote.repository
+
+import com.swm_standard.phote.entity.Exam
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ExamRepository : JpaRepository<Exam, Long>

--- a/src/main/kotlin/com/swm_standard/phote/repository/ExamRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/ExamRepository.kt
@@ -2,7 +2,5 @@ package com.swm_standard.phote.repository
 
 import com.swm_standard.phote.entity.Exam
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
 
-@Repository
 interface ExamRepository : JpaRepository<Exam, Long>

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -1,0 +1,39 @@
+package com.swm_standard.phote.service
+
+import com.swm_standard.phote.common.exception.NotFoundException
+import com.swm_standard.phote.dto.ReadExamHistoryDetail
+import com.swm_standard.phote.dto.ReadExamHistoryDetailResponse
+import com.swm_standard.phote.repository.ExamRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ExamService(
+    private val examRepository: ExamRepository
+) {
+    @Transactional(readOnly = true)
+    fun readExamHistoryDetail(id: Long): ReadExamHistoryDetailResponse {
+        val exam = examRepository.findById(id).orElseThrow{ NotFoundException("examId", "존재하지 않는 examId") }
+        val responses = mutableListOf<ReadExamHistoryDetail>()
+
+        exam.answers.map {
+            val options = it.question.options?.let { options ->
+                it.question.deserializeOptions()
+            }
+            responses.add(
+                ReadExamHistoryDetail(
+                    statement = it.question.statement,
+                    options = options,
+                    image = it.question.image,
+                    category = it.question.category,
+                    answer = it.question.answer,
+                    submittedAnswer = it.submittedAnswer,
+                    isCorrect = it.isCorrect,
+                    sequence = it.sequence
+                )
+            )
+        }
+
+        return ReadExamHistoryDetailResponse(id = exam.id, totalCorrect = exam.totalCorrect, time = exam.time, questions = responses)
+    }
+}

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -14,21 +14,22 @@ class ExamService(
     @Transactional(readOnly = true)
     fun readExamHistoryDetail(id: Long): ReadExamHistoryDetailResponse {
         val exam = examRepository.findById(id).orElseThrow { NotFoundException("examId", "존재하지 않는 examId") }
-        val responses = mutableListOf<ReadExamHistoryDetail>()
 
-        exam.answers.map { answer ->
-            responses.add(
-                ReadExamHistoryDetail(
-                    statement = answer.question.statement,
-                    options = answer.question.options?.let { answer.question.deserializeOptions() },
-                    image = answer.question.image,
-                    category = answer.question.category,
-                    answer = answer.question.answer,
-                    submittedAnswer = answer.submittedAnswer,
-                    isCorrect = answer.isCorrect,
-                    sequence = answer.sequence
+        val responses = buildList {
+            exam.answers.forEach { answer ->
+                add(
+                    ReadExamHistoryDetail(
+                        statement = answer.question.statement,
+                        options = answer.question.options?.let { answer.question.deserializeOptions() },
+                        image = answer.question.image,
+                        category = answer.question.category,
+                        answer = answer.question.answer,
+                        submittedAnswer = answer.submittedAnswer,
+                        isCorrect = answer.isCorrect,
+                        sequence = answer.sequence
+                    )
                 )
-            )
+            }
         }
 
         return ReadExamHistoryDetailResponse(

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -6,13 +6,14 @@ import com.swm_standard.phote.dto.ReadExamHistoryDetailResponse
 import com.swm_standard.phote.repository.ExamRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Service
 class ExamService(
     private val examRepository: ExamRepository
 ) {
     @Transactional(readOnly = true)
-    fun readExamHistoryDetail(id: Long): ReadExamHistoryDetailResponse {
+    fun readExamHistoryDetail(id: UUID): ReadExamHistoryDetailResponse {
         val exam = examRepository.findById(id).orElseThrow { NotFoundException("examId", "존재하지 않는 examId") }
 
         val responses = buildList {

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -13,27 +13,29 @@ class ExamService(
 ) {
     @Transactional(readOnly = true)
     fun readExamHistoryDetail(id: Long): ReadExamHistoryDetailResponse {
-        val exam = examRepository.findById(id).orElseThrow{ NotFoundException("examId", "존재하지 않는 examId") }
+        val exam = examRepository.findById(id).orElseThrow { NotFoundException("examId", "존재하지 않는 examId") }
         val responses = mutableListOf<ReadExamHistoryDetail>()
 
-        exam.answers.map {
-            val options = it.question.options?.let { options ->
-                it.question.deserializeOptions()
-            }
+        exam.answers.map { answer ->
             responses.add(
                 ReadExamHistoryDetail(
-                    statement = it.question.statement,
-                    options = options,
-                    image = it.question.image,
-                    category = it.question.category,
-                    answer = it.question.answer,
-                    submittedAnswer = it.submittedAnswer,
-                    isCorrect = it.isCorrect,
-                    sequence = it.sequence
+                    statement = answer.question.statement,
+                    options = answer.question.options?.let { answer.question.deserializeOptions() },
+                    image = answer.question.image,
+                    category = answer.question.category,
+                    answer = answer.question.answer,
+                    submittedAnswer = answer.submittedAnswer,
+                    isCorrect = answer.isCorrect,
+                    sequence = answer.sequence
                 )
             )
         }
 
-        return ReadExamHistoryDetailResponse(id = exam.id, totalCorrect = exam.totalCorrect, time = exam.time, questions = responses)
+        return ReadExamHistoryDetailResponse(
+            id = exam.id,
+            totalCorrect = exam.totalCorrect,
+            time = exam.time,
+            questions = responses
+        )
     }
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- Exam 엔티티에 문제풀이 시간, exam 순서 필드를 추가했습니다.
- Answer 엔티티 필드 몇개에 붙어있던 private을 제거했습니다. private가 붙어 있어서 참조가 안돼가지구..
- 명세서는 https://www.notion.so/readExamHistoryDetail-0306a41821384b30bdf726d0dc87bb35?pvs=4 여길 참고해주세용

---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close #132 
