### PR TITLE
Feat: readExamHistoryList 구현

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
@@ -2,6 +2,7 @@ package com.swm_standard.phote.controller
 
 import com.swm_standard.phote.common.responsebody.BaseResponse
 import com.swm_standard.phote.dto.ReadExamHistoryDetailResponse
+import com.swm_standard.phote.dto.ReadExamHistoryListResponse
 import com.swm_standard.phote.service.ExamService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
@@ -27,4 +28,14 @@ class ExamController(
         ) id: UUID
     ): BaseResponse<ReadExamHistoryDetailResponse> =
         BaseResponse(msg = "문제풀이 기록 상세조회 성공", data = examService.readExamHistoryDetail(id))
+
+    @Operation(summary = "readExamHistoryList", description = "문제풀이 기록 리스트 조회")
+    @SecurityRequirement(name = "bearer Auth")
+    @GetMapping("/exams/{workbookId}")
+    fun readExamHistoryList(
+        @PathVariable(
+            required = true
+        ) workbookId: UUID
+    ): BaseResponse<List<ReadExamHistoryListResponse>> =
+        BaseResponse(msg = "문제풀이 기록 리스트 조회 성공", data = examService.readExamHistoryList(workbookId))
 }

--- a/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
@@ -20,3 +20,11 @@ data class ReadExamHistoryDetailResponse(
     val time: Int,
     val questions: List<ReadExamHistoryDetail>
 )
+
+data class ReadExamHistoryListResponse(
+    val examId: UUID,
+    val totalQuantity: Int,
+    val totalCorrect: Int,
+    val time: Int,
+    val sequence: Int
+)

--- a/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
@@ -30,4 +30,8 @@ data class Exam(
     val time: Int = 0
 
     val sequence: Int = 0
+
+    fun calculateTotalQuantity(): Int {
+        return answers.size
+    }
 }

--- a/src/main/kotlin/com/swm_standard/phote/repository/ExamRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/ExamRepository.kt
@@ -4,4 +4,6 @@ import com.swm_standard.phote.entity.Exam
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface ExamRepository : JpaRepository<Exam, UUID>
+interface ExamRepository : JpaRepository<Exam, UUID> {
+    fun findAllByWorkbookId(workbookId: UUID): List<Exam>
+}

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -3,6 +3,7 @@ package com.swm_standard.phote.service
 import com.swm_standard.phote.common.exception.NotFoundException
 import com.swm_standard.phote.dto.ReadExamHistoryDetail
 import com.swm_standard.phote.dto.ReadExamHistoryDetailResponse
+import com.swm_standard.phote.dto.ReadExamHistoryListResponse
 import com.swm_standard.phote.repository.ExamRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -39,5 +40,19 @@ class ExamService(
             time = exam.time,
             questions = responses
         )
+    }
+
+    @Transactional(readOnly = true)
+    fun readExamHistoryList(workbookId: UUID): List<ReadExamHistoryListResponse> {
+        val exams = examRepository.findAllByWorkbookId(workbookId)
+        return exams.map { exam ->
+            ReadExamHistoryListResponse(
+                examId = exam.id,
+                totalQuantity = exam.calculateTotalQuantity(),
+                totalCorrect = exam.totalCorrect,
+                time = exam.time,
+                sequence = exam.sequence
+            )
+        }
     }
 }

--- a/src/test/kotlin/com/swm_standard/phote/entity/ExamTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/ExamTest.kt
@@ -1,0 +1,47 @@
+package com.swm_standard.phote.entity
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ExamTest {
+    private fun createExam(): Exam {
+
+        val member = Member("phote", "phote@test.com", "imageUrl", Provider.KAKAO)
+        val workbook = Workbook.createWorkbook(title = "testTitle", description = "", member = member)
+
+        val exam = Exam(
+            member = member,
+            workbook = workbook
+        )
+
+        val answer = Answer(
+            question = Question(
+                member = member,
+                statement = "모든 각이 동일한 삼각형은?",
+                image = "http://example.com/image.jpg",
+                answer = "정삼각형", category = Category.ESSAY,
+                memo = "삼각형 내각의 합은 180도이다."
+            ),
+            exam = exam,
+            submittedAnswer = "정삼각형",
+            isCorrect = true
+        )
+
+        exam.answers.add(answer)
+        exam.answers.add(answer)
+
+        return exam
+    }
+
+    @Test
+    fun `문제 풀이한 총 문제수를 구한다`() {
+        // given
+        val exam = createExam()
+
+        // when
+        val totalQuantity = exam.calculateTotalQuantity()
+
+        // then
+        assertEquals(totalQuantity, 2)
+    }
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- readExamHistoryList 구현
- 문제풀이의 총 문제 개수 구하는 로직을 비즈니스 로직으로 빼고 테스트코드 작성

---

### ✨ 참고 사항
- 테스트코드에서 createExam하는데 연관된게 너무 많아서 겁나 더러움 .. 그치만 달리 방법이 없음
- 만약 존재하지 않는 workbookId가 들어왔을 때 예외를 던져주려면 앞으로 사용하지도 않을건데``` workbookRepository.findById(id) ```해서 굳이 워크북 테이블을 봐야될 것 같아서 그냥 안했읍니다. . .
- 만약 시험 기록이 존재하지 않는 workbook 이라면 200성공이 뜨지만, data에 빈 리스트가 가는 것으로 구현했습니다.(시험기록이 없다고 해서 예외 던져주는건 좀 그래서.. 시험안본게 죄는 아니잖아! ㅋ.ㅋ)
---

### ⏰ 현재 버그

---

### ✏ Git Close #131 
