### PR TITLE
Feat: gradeExam

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -140,10 +140,11 @@ kapt {
 
 tasks.jacocoTestReport {
     reports {
-        html.required.set(false)
+        html.required.set(true)
         xml.required.set(true)
         csv.required.set(false)
 
+        html.outputLocation = file(project.layout.buildDirectory.dir("jacoco/index.html"))
         xml.outputLocation = file(project.layout.buildDirectory.dir("jacoco/index.xml"))
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
@@ -51,7 +51,7 @@ class ExamController(
     @PostMapping("/exam/{workbookId}")
     fun gradeExam(
         @PathVariable(required = true) workbookId: UUID,
-        @Valid @RequestBody request: List<GradeExamRequest>,
+        @Valid @RequestBody request: GradeExamRequest,
         @Parameter(hidden = true) @MemberId memberId: UUID,
     ): BaseResponse<GradeExamResponse> {
         val response = examService.gradeExam(workbookId, request, memberId)

--- a/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
@@ -1,31 +1,38 @@
 package com.swm_standard.phote.controller
 
+import com.swm_standard.phote.common.resolver.memberId.MemberId
 import com.swm_standard.phote.common.responsebody.BaseResponse
+import com.swm_standard.phote.dto.GradeExamRequest
+import com.swm_standard.phote.dto.GradeExamResponse
 import com.swm_standard.phote.dto.ReadExamHistoryDetailResponse
 import com.swm_standard.phote.dto.ReadExamHistoryListResponse
 import com.swm_standard.phote.service.ExamService
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.bind.annotation.RequestMapping
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
 @RestController
 @RequestMapping("/api")
 @Tag(name = "Exam", description = "Exam API Document")
 class ExamController(
-    private val examService: ExamService
+    private val examService: ExamService,
 ) {
     @Operation(summary = "readExamHistoryDetail", description = "문제풀이 기록 상세조회")
     @SecurityRequirement(name = "bearer Auth")
     @GetMapping("/exam/{id}")
     fun readExamHistoryDetail(
         @PathVariable(
-            required = true
-        ) id: UUID
+            required = true,
+        ) id: UUID,
     ): BaseResponse<ReadExamHistoryDetailResponse> =
         BaseResponse(msg = "문제풀이 기록 상세조회 성공", data = examService.readExamHistoryDetail(id))
 
@@ -34,8 +41,21 @@ class ExamController(
     @GetMapping("/exams/{workbookId}")
     fun readExamHistoryList(
         @PathVariable(
-            required = true
-        ) workbookId: UUID
+            required = true,
+        ) workbookId: UUID,
     ): BaseResponse<List<ReadExamHistoryListResponse>> =
         BaseResponse(msg = "문제풀이 기록 리스트 조회 성공", data = examService.readExamHistoryList(workbookId))
+
+    @Operation(summary = "gradeExam", description = "문제풀이 제출 및 채점")
+    @SecurityRequirement(name = "bearer Auth")
+    @PostMapping("/exam/{workbookId}")
+    fun gradeExam(
+        @PathVariable(required = true) workbookId: UUID,
+        @Valid @RequestBody request: List<GradeExamRequest>,
+        @Parameter(hidden = true) @MemberId memberId: UUID,
+    ): BaseResponse<GradeExamResponse> {
+        val response = examService.gradeExam(workbookId, request, memberId)
+
+        return BaseResponse(msg = "문제 풀이 채점 성공", data = response)
+    }
 }

--- a/src/main/kotlin/com/swm_standard/phote/dto/ChatGptDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ChatGptDtos.kt
@@ -1,7 +1,8 @@
 package com.swm_standard.phote.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.swm_standard.phote.external.chatgpt.PROMPT
+import com.swm_standard.phote.external.chatgpt.CHECK_ANSWER_PROMPT
+import com.swm_standard.phote.external.chatgpt.TRANSFORM_QUESTION_PROMPT
 
 data class RequestMessage(
     val role: String,
@@ -38,7 +39,18 @@ data class ChatGPTRequest(
             mutableListOf(
                 RequestMessage(
                     "user",
-                    mutableListOf(TextContent(PROMPT), ImageContent(ImageInfo(imageUrl))),
+                    mutableListOf(TextContent(TRANSFORM_QUESTION_PROMPT), ImageContent(ImageInfo(imageUrl))),
+                ),
+            ),
+        )
+
+    constructor(model: String, submittedAnswer: String, correctAnswer: String) :
+        this(
+            model,
+            mutableListOf(
+                RequestMessage(
+                    "user",
+                    mutableListOf(TextContent("$CHECK_ANSWER_PROMPT\n$submittedAnswer \n$correctAnswer")),
                 ),
             ),
         )

--- a/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
@@ -9,7 +9,7 @@ data class ReadExamHistoryDetail(
     val image: String?,
     val category: Category,
     val answer: String,
-    val submittedAnswer: String,
+    val submittedAnswer: String?,
     val isCorrect: Boolean,
     val sequence: Int,
 )
@@ -43,7 +43,7 @@ data class GradeExamResponse(
 
 data class AnswerResponse(
     val questionId: UUID,
-    val submittedAnswer: String,
+    val submittedAnswer: String?,
     val correctAnswer: String,
     val isCorrect: Boolean,
 )

--- a/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
@@ -30,6 +30,11 @@ data class ReadExamHistoryListResponse(
 )
 
 data class GradeExamRequest(
+    val time: Int,
+    val answers: List<SubmittedAnswerRequest>,
+)
+
+data class SubmittedAnswerRequest(
     val questionId: UUID,
     val submittedAnswer: String?,
 )

--- a/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
@@ -11,14 +11,14 @@ data class ReadExamHistoryDetail(
     val answer: String,
     val submittedAnswer: String,
     val isCorrect: Boolean,
-    val sequence: Int
+    val sequence: Int,
 )
 
 data class ReadExamHistoryDetailResponse(
     val id: UUID,
     val totalCorrect: Int,
     val time: Int,
-    val questions: List<ReadExamHistoryDetail>
+    val questions: List<ReadExamHistoryDetail>,
 )
 
 data class ReadExamHistoryListResponse(
@@ -26,5 +26,24 @@ data class ReadExamHistoryListResponse(
     val totalQuantity: Int,
     val totalCorrect: Int,
     val time: Int,
-    val sequence: Int
+    val sequence: Int,
+)
+
+data class GradeExamRequest(
+    val questionId: UUID,
+    val submittedAnswer: String,
+)
+
+data class GradeExamResponse(
+    val examId: UUID,
+    val totalCorrect: Int,
+    val questionQuantity: Int,
+    val answers: List<AnswerResponse>,
+)
+
+data class AnswerResponse(
+    val questionId: UUID,
+    val submittedAnswer: String,
+    val correctAnswer: String,
+    val isCorrect: Boolean,
 )

--- a/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
@@ -31,7 +31,7 @@ data class ReadExamHistoryListResponse(
 
 data class GradeExamRequest(
     val questionId: UUID,
-    val submittedAnswer: String,
+    val submittedAnswer: String?,
 )
 
 data class GradeExamResponse(

--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -6,7 +6,7 @@ import com.swm_standard.phote.entity.Category
 import com.swm_standard.phote.entity.Tag
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
-import jakarta.validation.constraints.PositiveOrZero
+import jakarta.validation.constraints.Positive
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -65,7 +65,7 @@ data class DeleteQuestionInWorkbookResponse(
 data class UpdateQuestionSequenceRequest(
     @JsonProperty("id")
     private val _id: UUID?,
-    @field:PositiveOrZero(message = "sequence는 0 이상의 정수만 가능합니다.")
+    @field:Positive(message = "sequence는 1 이상의 정수만 가능합니다.")
     @JsonProperty("sequence")
     private val _sequence: Int?,
 ) {

--- a/src/main/kotlin/com/swm_standard/phote/entity/Answer.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Answer.kt
@@ -18,12 +18,39 @@ data class Answer(
     val exam: Exam,
     @Column(name = "submitted_answer")
     val submittedAnswer: String,
-    val isCorrect: Boolean,
+    val sequence: Int,
 ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "answer_id")
     val id: Long = 0
 
-    val sequence: Int = 0
+    var isCorrect: Boolean = false
+
+    companion object {
+        fun createAnswer(
+            question: Question,
+            exam: Exam,
+            submittedAnswer: String,
+            sequence: Int,
+        ) = Answer(
+            question,
+            exam,
+            submittedAnswer,
+            sequence,
+        )
+    }
+
+    /**
+     * 객관식 문제면 정오답 체크를 하고 true 반환,
+     * 주관식 문제면 정오답 여부 판별 없이 false 반환 -> ChatGPT를 이용해야 하기 때문
+     **/
+    fun isMultipleAndCheckAnswer(): Boolean {
+        if (question.category == Category.MULTIPLE) {
+            isCorrect = submittedAnswer == question.answer
+            return true
+        } else {
+            return false
+        }
+    }
 }

--- a/src/main/kotlin/com/swm_standard/phote/entity/Answer.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Answer.kt
@@ -17,7 +17,7 @@ data class Answer(
     @JoinColumn(name = "exam_id")
     val exam: Exam,
     @Column(name = "submitted_answer")
-    val submittedAnswer: String,
+    val submittedAnswer: String?,
     val sequence: Int,
 ) : BaseTimeEntity() {
     @Id
@@ -31,7 +31,7 @@ data class Answer(
         fun createAnswer(
             question: Question,
             exam: Exam,
-            submittedAnswer: String,
+            submittedAnswer: String?,
             sequence: Int,
         ) = Answer(
             question,

--- a/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
@@ -20,6 +20,7 @@ data class Exam(
     @JoinColumn(name = "workbook_id")
     val workbook: Workbook,
     val sequence: Int,
+    val time: Int,
 ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -31,8 +32,6 @@ data class Exam(
     @OneToMany(mappedBy = "exam", cascade = [(CascadeType.REMOVE)])
     val answers: MutableList<Answer> = mutableListOf()
 
-    val time: Int = 0
-
     fun calculateTotalQuantity(): Int = answers.size
 
     companion object {
@@ -40,7 +39,8 @@ data class Exam(
             member: Member,
             workbook: Workbook,
             sequence: Int,
-        ) = Exam(member, workbook, sequence)
+            time: Int,
+        ) = Exam(member, workbook, sequence, time)
     }
 
     fun increaseTotalCorrect(count: Int) {

--- a/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
@@ -3,6 +3,8 @@ package com.swm_standard.phote.entity
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
@@ -20,8 +22,9 @@ data class Exam(
     val sequence: Int,
 ) : BaseTimeEntity() {
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "exam_id", nullable = false, unique = true)
-    val id: UUID = UUID.randomUUID()
+    var id: UUID? = null
 
     var totalCorrect: Int = 0
 
@@ -40,7 +43,7 @@ data class Exam(
         ) = Exam(member, workbook, sequence)
     }
 
-    fun increaseTotalCorrect() {
-        totalCorrect += 1
+    fun increaseTotalCorrect(count: Int) {
+        totalCorrect += count
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
@@ -17,21 +17,30 @@ data class Exam(
     @ManyToOne
     @JoinColumn(name = "workbook_id")
     val workbook: Workbook,
+    val sequence: Int,
 ) : BaseTimeEntity() {
     @Id
     @Column(name = "exam_id", nullable = false, unique = true)
     val id: UUID = UUID.randomUUID()
 
-    val totalCorrect: Int = 0
+    var totalCorrect: Int = 0
 
     @OneToMany(mappedBy = "exam", cascade = [(CascadeType.REMOVE)])
     val answers: MutableList<Answer> = mutableListOf()
 
     val time: Int = 0
 
-    val sequence: Int = 0
+    fun calculateTotalQuantity(): Int = answers.size
 
-    fun calculateTotalQuantity(): Int {
-        return answers.size
+    companion object {
+        fun createExam(
+            member: Member,
+            workbook: Workbook,
+            sequence: Int,
+        ) = Exam(member, workbook, sequence)
+    }
+
+    fun increaseTotalCorrect() {
+        totalCorrect += 1
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/external/chatgpt/Prompt.kt
+++ b/src/main/kotlin/com/swm_standard/phote/external/chatgpt/Prompt.kt
@@ -1,5 +1,8 @@
 package com.swm_standard.phote.external.chatgpt
 
-const val PROMPT: String =
+const val TRANSFORM_QUESTION_PROMPT: String =
     "너는 지금부터 텍스트 추출기야. 위에 첨부한 사진에서 문제 문항에 해당하는 텍스트와" +
         "객관식 문제라면 선택지 텍스트를 #로 분리해서 추출해줘. 다른 대답없이 텍스트만 보내줘"
+
+const val CHECK_ANSWER_PROMPT: String =
+    "너는 지금부터 주관식 채점기야. 첫번째 문단으로 보내는 제출 답안과 두번째 문단으로 보내는 정답의 유사도를 기준으로 정오답을 판단해줘. 대답은 true 또는 false 로 해줘."

--- a/src/main/kotlin/com/swm_standard/phote/external/chatgpt/Prompt.kt
+++ b/src/main/kotlin/com/swm_standard/phote/external/chatgpt/Prompt.kt
@@ -1,8 +1,7 @@
 package com.swm_standard.phote.external.chatgpt
 
 const val TRANSFORM_QUESTION_PROMPT: String =
-    "너는 지금부터 텍스트 추출기야. 위에 첨부한 사진에서 문제 문항에 해당하는 텍스트와" +
-        "객관식 문제라면 선택지 텍스트를 #로 분리해서 추출해줘. 다른 대답없이 텍스트만 보내줘"
+    "You are now a text extractor. Extract the text corresponding to the questions from the attached image. If it’s a multiple-choice question, separate the choices with #. Send only the extracted text without any other responses."
 
 const val CHECK_ANSWER_PROMPT: String =
     "너는 지금부터 주관식 채점기야. 첫번째 문단으로 보내는 제출 답안과 두번째 문단으로 보내는 정답의 유사도를 기준으로 정오답을 판단해줘. 대답은 true 또는 false 로 해줘."

--- a/src/main/kotlin/com/swm_standard/phote/external/chatgpt/Prompt.kt
+++ b/src/main/kotlin/com/swm_standard/phote/external/chatgpt/Prompt.kt
@@ -1,7 +1,10 @@
 package com.swm_standard.phote.external.chatgpt
 
 const val TRANSFORM_QUESTION_PROMPT: String =
-    "You are now a text extractor. Extract the text corresponding to the questions from the attached image. If it’s a multiple-choice question, separate the choices with #. Send only the extracted text without any other responses."
+    "You are now a text extractor. Extract the text corresponding to the questions from the attached image. " +
+        "If it’s a multiple-choice question, separate the choices with #. " +
+        "Send only the extracted text without any other responses."
 
 const val CHECK_ANSWER_PROMPT: String =
-    "너는 지금부터 주관식 채점기야. 첫번째 문단으로 보내는 제출 답안과 두번째 문단으로 보내는 정답의 유사도를 기준으로 정오답을 판단해줘. 대답은 true 또는 false 로 해줘."
+    "너는 지금부터 주관식 채점기야. 첫번째 문단으로 보내는 제출 답안과 두번째 문단으로 보내는 정답의 유사도를 기준으로 정오답을 판단해줘. " +
+        "대답은 true 또는 false 로 해줘."

--- a/src/main/kotlin/com/swm_standard/phote/repository/AnswerRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/AnswerRepository.kt
@@ -1,0 +1,7 @@
+package com.swm_standard.phote.repository
+
+import com.swm_standard.phote.entity.Answer
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface AnswerRepository : JpaRepository<Answer, UUID>

--- a/src/main/kotlin/com/swm_standard/phote/repository/ExamCustomRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/ExamCustomRepository.kt
@@ -1,0 +1,7 @@
+package com.swm_standard.phote.repository
+
+import com.swm_standard.phote.entity.Workbook
+
+interface ExamCustomRepository {
+    fun findMaxSequenceByWorkbookId(workbook: Workbook): Int
+}

--- a/src/main/kotlin/com/swm_standard/phote/repository/ExamCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/ExamCustomRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.swm_standard.phote.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.swm_standard.phote.entity.QExam.exam
+import com.swm_standard.phote.entity.Workbook
+import org.springframework.stereotype.Repository
+
+@Repository
+class ExamCustomRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory,
+) : ExamCustomRepository {
+    override fun findMaxSequenceByWorkbookId(workbook: Workbook): Int {
+        val maxSequence: Int? =
+            jpaQueryFactory
+                .select(exam.sequence.max())
+                .from(exam)
+                .where(exam.workbook.eq(workbook))
+                .fetchOne()
+
+        if (maxSequence == null) return 0
+        return maxSequence
+    }
+}

--- a/src/main/kotlin/com/swm_standard/phote/repository/ExamRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/ExamRepository.kt
@@ -4,6 +4,8 @@ import com.swm_standard.phote.entity.Exam
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface ExamRepository : JpaRepository<Exam, UUID> {
+interface ExamRepository :
+    JpaRepository<Exam, UUID>,
+    ExamCustomRepository {
     fun findAllByWorkbookId(workbookId: UUID): List<Exam>
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -9,6 +9,7 @@ import com.swm_standard.phote.dto.GradeExamResponse
 import com.swm_standard.phote.dto.ReadExamHistoryDetail
 import com.swm_standard.phote.dto.ReadExamHistoryDetailResponse
 import com.swm_standard.phote.dto.ReadExamHistoryListResponse
+import com.swm_standard.phote.dto.SubmittedAnswerRequest
 import com.swm_standard.phote.entity.Answer
 import com.swm_standard.phote.entity.Exam
 import com.swm_standard.phote.entity.Question
@@ -86,7 +87,7 @@ class ExamService(
     @Transactional
     fun gradeExam(
         workbookId: UUID,
-        request: List<GradeExamRequest>,
+        request: GradeExamRequest,
         memberId: UUID,
     ): GradeExamResponse {
         val workbook =
@@ -102,13 +103,14 @@ class ExamService(
                         memberRepository.findById(memberId).getOrElse { throw NotFoundException(fieldName = "member") },
                         workbook,
                         examRepository.findMaxSequenceByWorkbookId(workbook) + 1,
+                        request.time,
                     ),
             )
 
         var totalCorrect = 0
 
         val response =
-            request.mapIndexed { index: Int, answer: GradeExamRequest ->
+            request.answers.mapIndexed { index: Int, answer: SubmittedAnswerRequest ->
                 val question: Question =
                     questionRepository.findById(answer.questionId).getOrElse {
                         throw NotFoundException(fieldName = "questionId (${answer.questionId})")

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -122,9 +122,11 @@ class ExamService(
                         sequence = index + 1,
                     )
 
-                if (!savingAnswer.isMultipleAndCheckAnswer()) {
+                if (savingAnswer.submittedAnswer == null) {
+                    savingAnswer.isCorrect = false
+                } else if (!savingAnswer.isMultipleAndCheckAnswer()) {
                     val chatGptRequest =
-                        ChatGPTRequest(model, savingAnswer.submittedAnswer, savingAnswer.question.answer)
+                        ChatGPTRequest(model, savingAnswer.submittedAnswer!!, savingAnswer.question.answer)
 
                     val chatGPTResponse = template.postForObject(url, chatGptRequest, ChatGPTResponse::class.java)
 

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -1,44 +1,71 @@
 package com.swm_standard.phote.service
 
 import com.swm_standard.phote.common.exception.NotFoundException
+import com.swm_standard.phote.dto.AnswerResponse
+import com.swm_standard.phote.dto.ChatGPTRequest
+import com.swm_standard.phote.dto.ChatGPTResponse
+import com.swm_standard.phote.dto.GradeExamRequest
+import com.swm_standard.phote.dto.GradeExamResponse
 import com.swm_standard.phote.dto.ReadExamHistoryDetail
 import com.swm_standard.phote.dto.ReadExamHistoryDetailResponse
 import com.swm_standard.phote.dto.ReadExamHistoryListResponse
+import com.swm_standard.phote.entity.Answer
+import com.swm_standard.phote.entity.Exam
+import com.swm_standard.phote.entity.Question
+import com.swm_standard.phote.repository.AnswerRepository
 import com.swm_standard.phote.repository.ExamRepository
+import com.swm_standard.phote.repository.MemberRepository
+import com.swm_standard.phote.repository.QuestionRepository
+import com.swm_standard.phote.repository.WorkbookRepository
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.client.RestTemplate
 import java.util.UUID
+import kotlin.jvm.optionals.getOrElse
 
 @Service
 class ExamService(
-    private val examRepository: ExamRepository
+    private val examRepository: ExamRepository,
+    private val questionRepository: QuestionRepository,
+    private val workbookRepository: WorkbookRepository,
+    private val memberRepository: MemberRepository,
+    private val answerRepository: AnswerRepository,
+    private val template: RestTemplate,
 ) {
+    @Value("\${openai.model}")
+    lateinit var model: String
+
+    @Value("\${openai.api.url}")
+    lateinit var url: String
+
     @Transactional(readOnly = true)
     fun readExamHistoryDetail(id: UUID): ReadExamHistoryDetailResponse {
         val exam = examRepository.findById(id).orElseThrow { NotFoundException("examId", "존재하지 않는 examId") }
 
-        val responses = buildList {
-            exam.answers.forEach { answer ->
-                add(
-                    ReadExamHistoryDetail(
-                        statement = answer.question.statement,
-                        options = answer.question.options?.let { answer.question.deserializeOptions() },
-                        image = answer.question.image,
-                        category = answer.question.category,
-                        answer = answer.question.answer,
-                        submittedAnswer = answer.submittedAnswer,
-                        isCorrect = answer.isCorrect,
-                        sequence = answer.sequence
+        val responses =
+            buildList {
+                exam.answers.forEach { answer ->
+                    add(
+                        ReadExamHistoryDetail(
+                            statement = answer.question.statement,
+                            options = answer.question.options?.let { answer.question.deserializeOptions() },
+                            image = answer.question.image,
+                            category = answer.question.category,
+                            answer = answer.question.answer,
+                            submittedAnswer = answer.submittedAnswer,
+                            isCorrect = answer.isCorrect,
+                            sequence = answer.sequence,
+                        ),
                     )
-                )
+                }
             }
-        }
 
         return ReadExamHistoryDetailResponse(
             id = exam.id,
             totalCorrect = exam.totalCorrect,
             time = exam.time,
-            questions = responses
+            questions = responses,
         )
     }
 
@@ -51,8 +78,78 @@ class ExamService(
                 totalQuantity = exam.calculateTotalQuantity(),
                 totalCorrect = exam.totalCorrect,
                 time = exam.time,
-                sequence = exam.sequence
+                sequence = exam.sequence,
             )
         }
+    }
+
+    @Transactional
+    fun gradeExam(
+        workbookId: UUID,
+        request: List<GradeExamRequest>,
+        memberId: UUID,
+    ): GradeExamResponse {
+        val workbook =
+            workbookRepository
+                .findById(
+                    workbookId,
+                ).getOrElse { throw NotFoundException(fieldName = "workbook") }
+
+        val exam =
+            examRepository.save(
+                Exam
+                    .createExam(
+                        memberRepository.findById(memberId).getOrElse { throw NotFoundException(fieldName = "member") },
+                        workbook,
+                        examRepository.findMaxSequenceByWorkbookId(workbook) + 1,
+                    ),
+            )
+
+        val response =
+            request.mapIndexed { index: Int, answer: GradeExamRequest ->
+                val question: Question =
+                    questionRepository.findById(answer.questionId).getOrElse {
+                        throw NotFoundException(fieldName = "questionId (${answer.questionId})")
+                    }
+
+                val savingAnswer: Answer =
+                    answerRepository.save(
+                        Answer.createAnswer(
+                            question = question,
+                            submittedAnswer = answer.submittedAnswer,
+                            exam = exam,
+                            sequence = index,
+                        ),
+                    )
+
+                if (!savingAnswer.isMultipleAndCheckAnswer()) {
+                    val chatGptRequest =
+                        ChatGPTRequest(model, savingAnswer.submittedAnswer, savingAnswer.question.answer)
+
+                    val chatGPTResponse = template.postForObject(url, chatGptRequest, ChatGPTResponse::class.java)
+
+                    savingAnswer.isCorrect =
+                        when (chatGPTResponse!!.choices[0].message.content) {
+                            "true" -> true
+                            else -> false
+                        }
+
+                    if (savingAnswer.isCorrect) exam.increaseTotalCorrect()
+                }
+
+                AnswerResponse(
+                    questionId = savingAnswer.question.id,
+                    submittedAnswer = savingAnswer.submittedAnswer,
+                    correctAnswer = savingAnswer.question.answer,
+                    isCorrect = savingAnswer.isCorrect,
+                )
+            }
+
+        return GradeExamResponse(
+            examId = exam.id,
+            totalCorrect = exam.totalCorrect,
+            questionQuantity = response.size,
+            answers = response,
+        )
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -106,7 +106,7 @@ class WorkbookService(
                     .getOrElse { throw NotFoundException(fieldName = "question", message = "id 를 재확인해주세요.") }
 
             if (questionSetRepository
-                    .existsByQuestionIdAndWorkbookId(questionId, workbook.id)
+                .existsByQuestionIdAndWorkbookId(questionId, workbook.id)
             ) {
                 throw AlreadyExistedException("questionId ($questionId)")
             }

--- a/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
@@ -30,6 +30,19 @@ class AnswerTest {
         Assertions.assertFalse(checkAnswer)
     }
 
+    @Test
+    fun `답안이 null이면 isCorrect는 false로 체크한다`() {
+        val category = Category.MULTIPLE
+        val submittedAnswer = null
+        val correctAnswer = "5"
+        val answer = createAnswer(category, submittedAnswer, correctAnswer)
+
+        val checkAnswer = answer.isMultipleAndCheckAnswer()
+
+        Assertions.assertTrue(checkAnswer)
+        Assertions.assertFalse(answer.isCorrect)
+    }
+
     fun createWorkbook(): Workbook =
         Workbook(
             title = "hinc",
@@ -55,7 +68,7 @@ class AnswerTest {
 
     fun createAnswer(
         category: Category,
-        submittedAnswer: String,
+        submittedAnswer: String?,
         correctAnswer: String,
     ) = Answer(
         question =

--- a/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
@@ -64,6 +64,7 @@ class AnswerTest {
             member = createMember(),
             workbook = createWorkbook(),
             sequence = 4282,
+            time = 40,
         )
 
     fun createAnswer(

--- a/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
@@ -1,0 +1,71 @@
+package com.swm_standard.phote.entity
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class AnswerTest {
+    @Test
+    fun `문제가 객관식이면 정오답 체크를 하고 틀릴 경우 isCorrect가 false가 된다`() {
+        val category = Category.MULTIPLE
+        val submittedAnswer = "1"
+        val correctAnswer = "5"
+        val answer = createAnswer(category, submittedAnswer, correctAnswer)
+
+        val checkAnswer = answer.isMultipleAndCheckAnswer()
+
+        Assertions.assertTrue(checkAnswer)
+        Assertions.assertFalse(answer.isCorrect)
+    }
+
+    fun createWorkbook(): Workbook =
+        Workbook(
+            title = "hinc",
+            description = null,
+            member = createMember(),
+            emoji = "📚",
+        )
+
+    fun createMember(): Member =
+        Member(
+            name = "Mayra Payne",
+            email = "penelope.mccarty@example.com",
+            image = "dicant",
+            provider = Provider.APPLE,
+        )
+
+    fun createExam() =
+        Exam(
+            member = createMember(),
+            workbook = createWorkbook(),
+            sequence = 4282,
+        )
+
+    fun createAnswer(
+        category: Category,
+        submittedAnswer: String,
+        correctAnswer: String,
+    ) = Answer(
+        question =
+            Question(
+                id = UUID.randomUUID(),
+                member =
+                    Member(
+                        name = "Erik Ashley",
+                        email = "jay.combs@example.com",
+                        image = "per",
+                        provider = Provider.APPLE,
+                    ),
+                statement = "Kentucky",
+                options = null,
+                image = null,
+                answer = correctAnswer,
+                category = category,
+                questionSet = listOf(),
+                memo = null,
+            ),
+        exam = createExam(),
+        submittedAnswer = "euismod",
+        sequence = 2017,
+    )
+}

--- a/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
@@ -72,23 +72,23 @@ class AnswerTest {
         correctAnswer: String,
     ) = Answer(
         question =
-            Question(
-                id = UUID.randomUUID(),
-                member =
-                    Member(
-                        name = "Erik Ashley",
-                        email = "jay.combs@example.com",
-                        image = "per",
-                        provider = Provider.APPLE,
-                    ),
-                statement = "Kentucky",
-                options = null,
-                image = null,
-                answer = correctAnswer,
-                category = category,
-                questionSet = listOf(),
-                memo = null,
+        Question(
+            id = UUID.randomUUID(),
+            member =
+            Member(
+                name = "Erik Ashley",
+                email = "jay.combs@example.com",
+                image = "per",
+                provider = Provider.APPLE,
             ),
+            statement = "Kentucky",
+            options = null,
+            image = null,
+            answer = correctAnswer,
+            category = category,
+            questionSet = listOf(),
+            memo = null,
+        ),
         exam = createExam(),
         submittedAnswer = "euismod",
         sequence = 2017,

--- a/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
@@ -18,6 +18,18 @@ class AnswerTest {
         Assertions.assertFalse(answer.isCorrect)
     }
 
+    @Test
+    fun `문제가 주관식이면 false를 반환한다`() {
+        val category = Category.ESSAY
+        val submittedAnswer = "essay test"
+        val correctAnswer = "essay test"
+        val answer = createAnswer(category, submittedAnswer, correctAnswer)
+
+        val checkAnswer = answer.isMultipleAndCheckAnswer()
+
+        Assertions.assertFalse(checkAnswer)
+    }
+
     fun createWorkbook(): Workbook =
         Workbook(
             title = "hinc",

--- a/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
@@ -90,7 +90,7 @@ class AnswerTest {
             memo = null,
         ),
         exam = createExam(),
-        submittedAnswer = "euismod",
+        submittedAnswer = submittedAnswer,
         sequence = 2017,
     )
 }

--- a/src/test/kotlin/com/swm_standard/phote/entity/ExamTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/ExamTest.kt
@@ -19,14 +19,14 @@ class ExamTest {
         val answer =
             Answer(
                 question =
-                    Question(
-                        member = member,
-                        statement = "모든 각이 동일한 삼각형은?",
-                        image = "http://example.com/image.jpg",
-                        answer = "정삼각형",
-                        category = Category.ESSAY,
-                        memo = "삼각형 내각의 합은 180도이다.",
-                    ),
+                Question(
+                    member = member,
+                    statement = "모든 각이 동일한 삼각형은?",
+                    image = "http://example.com/image.jpg",
+                    answer = "정삼각형",
+                    category = Category.ESSAY,
+                    memo = "삼각형 내각의 합은 180도이다.",
+                ),
                 exam = exam,
                 submittedAnswer = "정삼각형",
                 sequence = 1,

--- a/src/test/kotlin/com/swm_standard/phote/entity/ExamTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/ExamTest.kt
@@ -14,6 +14,7 @@ class ExamTest {
                 member = member,
                 workbook = workbook,
                 sequence = 1,
+                time = 30,
             )
 
         val answer =
@@ -57,8 +58,9 @@ class ExamTest {
         val workbook = createWorkbook()
         val member = createMember()
         val sequence: Int = 2
+        val time = 20
 
-        val exam = Exam.createExam(member, workbook, sequence)
+        val exam = Exam.createExam(member, workbook, sequence, time)
 
         Assertions.assertThat(exam.workbook).isEqualTo(workbook)
         Assertions.assertThat(exam.member).isEqualTo(member)

--- a/src/test/kotlin/com/swm_standard/phote/entity/ExamTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/ExamTest.kt
@@ -1,31 +1,38 @@
 package com.swm_standard.phote.entity
 
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class ExamTest {
     private fun createExam(): Exam {
-
         val member = Member("phote", "phote@test.com", "imageUrl", Provider.KAKAO)
         val workbook = Workbook.createWorkbook(title = "testTitle", description = "", member = member)
 
-        val exam = Exam(
-            member = member,
-            workbook = workbook
-        )
-
-        val answer = Answer(
-            question = Question(
+        val exam =
+            Exam(
                 member = member,
-                statement = "모든 각이 동일한 삼각형은?",
-                image = "http://example.com/image.jpg",
-                answer = "정삼각형", category = Category.ESSAY,
-                memo = "삼각형 내각의 합은 180도이다."
-            ),
-            exam = exam,
-            submittedAnswer = "정삼각형",
-            isCorrect = true
-        )
+                workbook = workbook,
+                sequence = 1,
+            )
+
+        val answer =
+            Answer(
+                question =
+                    Question(
+                        member = member,
+                        statement = "모든 각이 동일한 삼각형은?",
+                        image = "http://example.com/image.jpg",
+                        answer = "정삼각형",
+                        category = Category.ESSAY,
+                        memo = "삼각형 내각의 합은 180도이다.",
+                    ),
+                exam = exam,
+                submittedAnswer = "정삼각형",
+                sequence = 1,
+            )
+
+        answer.isCorrect = true
 
         exam.answers.add(answer)
         exam.answers.add(answer)
@@ -44,4 +51,43 @@ class ExamTest {
         // then
         assertEquals(totalQuantity, 2)
     }
+
+    @Test
+    fun `시험 생성에 성공한다`() {
+        val workbook = createWorkbook()
+        val member = createMember()
+        val sequence: Int = 2
+
+        val exam = Exam.createExam(member, workbook, sequence)
+
+        Assertions.assertThat(exam.workbook).isEqualTo(workbook)
+        Assertions.assertThat(exam.member).isEqualTo(member)
+        Assertions.assertThat(exam.sequence).isEqualTo(sequence)
+    }
+
+    @Test
+    fun `totalCorrect가 1 증가한다`() {
+        val exam = createExam()
+        val totalCorrect = exam.totalCorrect
+
+        exam.increaseTotalCorrect()
+
+        Assertions.assertThat(exam.totalCorrect).isEqualTo(totalCorrect + 1)
+    }
+
+    fun createWorkbook(): Workbook =
+        Workbook(
+            title = "hinc",
+            description = null,
+            member = createMember(),
+            emoji = "📚",
+        )
+
+    fun createMember(): Member =
+        Member(
+            name = "Mayra Payne",
+            email = "penelope.mccarty@example.com",
+            image = "dicant",
+            provider = Provider.APPLE,
+        )
 }

--- a/src/test/kotlin/com/swm_standard/phote/entity/ExamTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/ExamTest.kt
@@ -66,13 +66,14 @@ class ExamTest {
     }
 
     @Test
-    fun `totalCorrect가 1 증가한다`() {
+    fun `totalCorrect가 증가한다`() {
         val exam = createExam()
+        val count = 3
         val totalCorrect = exam.totalCorrect
 
-        exam.increaseTotalCorrect()
+        exam.increaseTotalCorrect(count)
 
-        Assertions.assertThat(exam.totalCorrect).isEqualTo(totalCorrect + 1)
+        Assertions.assertThat(exam.totalCorrect).isEqualTo(totalCorrect + count)
     }
 
     fun createWorkbook(): Workbook =

--- a/src/test/kotlin/com/swm_standard/phote/entity/WorkbookTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/WorkbookTest.kt
@@ -7,7 +7,7 @@ import java.time.LocalDateTime
 class WorkbookTest {
     @Test
     fun `문제집을 생성한다`() {
-        val member: Member = createmember()
+        val member: Member = createMember()
         val testTitle = "테스트 제목 수학"
 
         val workbook: Workbook = Workbook.createWorkbook(title = testTitle, description = "", member = member)
@@ -58,11 +58,11 @@ class WorkbookTest {
         Workbook(
             title = "hinc",
             description = null,
-            member = createmember(),
+            member = createMember(),
             emoji = "📚",
         )
 
-    fun createmember(): Member =
+    fun createMember(): Member =
         Member(
             name = "Mayra Payne",
             email = "penelope.mccarty@example.com",


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 문제 풀이 제출 시 채점 결과를 응답으로 보내는 기능을 구현했습니다.
- 주관식 문제인 경우 ChatGPT를 통해 유사도를 측정하여 정오답을 체크하는데 이는 단순하므로 `gpt-4o-mini` (하위 버전) 을 사용하는 것으로 결정했습니다.
    - 더 저렴할 것 같은 `gpt-3.5-turbo` 로 고려했는데 공식 문서에서 2024년 7월부로  터보 버전 대신 4o mini 버전을 권장한다고 합니다


**<응답 바디 예시>**

<img width="400" alt="스크린샷 2024-08-02 오후 12 28 43" src="https://github.com/user-attachments/assets/3f2e271c-e67a-4f68-a042-3d866db4a633">


---

### ✨ 참고 사항


- `Answer` 클래스의`isMultipleAndCheckAnswer()` 이 모냥이 조금 애매하네요..  객관식인 경우 문자열 비교만 하면 되서 해당 메서드 내에서 채점까지 하고, 주관식인 경우에는 chatgpt 외부 의존성이 있어서 false 만 반환하고 `AnswerService` 에서 chatGPT 호출할 수 있도록 했습니다. -> 멘토님께 개선 방향을 여줘보려고 합니다!
- api 전반의 sequence 는 1부터 하는걸로 변경했습니다 (기존에는 0 이상 정수) 확인 부탁드려요 @Goonco 

---

### ⏰ 현재 버그

- 프롬프트를 영어로 변환해보았는데 문제 변환 기능에서는 영어 프롬프트가 제대로 실행되는 듯한데, 채점 기능에서는 제가 보기에 유사하고, 또한 한글 프롬프트에서는 `true`라고 판단한 답변도 `false` 라고 답하는 경우가 잦아서 일단은 한글로 유지해두고 있습니다. (토큰 수가 많이 차이나서 이것도 언젠간 영어 프롬프트로 바꾸긴 해야할 듯 합니다)

**<⚠️ 오류 예시 >**
<img width="400" alt="스크린샷 2024-08-02 오전 10 30 43" src="https://github.com/user-attachments/assets/926fd34b-3ce9-4c68-b2a6-38e4fac56595">

- 해당 기능에서 쿼리 개수가 상당히 많습니다. (현재 11번 쿼리 요청)
    - 여기에는 exam 처럼 db에 새로  save되는 엔티티들이 save 전에 select 쿼리 요청을 추가로 해서 더 길어진 것 같습니다. 이유는 엔티티 생성 시에  id 필드에 UUID.random~ 으로 값을 채우면서 JPA에서 해당 엔티티를 `isNew = false` 로 인식해서 select로 확인을 거친다고 합니다.
    - 따라서 Exam 엔티티의 id를 시험삼아 `@GeneratedValue(strategy = GenerationType.UUID)` 로 생성 후에 id 값을 채우도록 했고 성공적으로  쿼리 개수를 줄일 수 있었습니다.
    - 다른 엔티티의 id 필드도 이렇게 전환하면 어떨까 제안합니다! (공식 문서에서도 id 는 nullable로 한다네요)
    - 이 때문에 @RinRinPARK 님이 작성하신 dto 일부분의 id 필드에 `!!` 을 추가했습니다!




---

### ✏ Git Close
- #135 
