### PR TITLE
Feat: transformQuestion 그림 변환 구현

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
@@ -92,9 +92,10 @@ class QuestionController(
     @PostMapping("question-transform")
     fun transformQuestion(
         @RequestPart image: MultipartFile?,
+        @RequestPart imageCoordinates: List<List<Int>>? = null
     ): BaseResponse<TransformQuestionResponse> {
         val imageUrl = image?.let { s3Service.uploadChatGptImage(it) }
-        val response: TransformQuestionResponse = questionService.transformQuestion(imageUrl!!)
+        val response: TransformQuestionResponse = questionService.transformQuestion(imageUrl!!, imageCoordinates)
 
         return BaseResponse(data = response, msg = "문제 변환 성공")
     }

--- a/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/QuestionDtos.kt
@@ -96,4 +96,5 @@ data class SearchQuestionsToAddResponse(
 data class TransformQuestionResponse(
     val content: String,
     val options: List<String>,
+    val transformedImageUrl: String?
 )


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- transformQuestion의 그림변환 부분을 추가했습니다.
- AWS의 Lambda와 API Gateway를 이용해서 따로 파이썬 코드 서버(?, 서버리스인디..)를 구축했습니다. 혼자서 나름 챌린지했습니다;;;
- 왜 lambda를 이용했는지.. 기타 자세한 내용은 [위키](https://swm-standard.github.io/phote-wiki/aws-lambda%EC%99%80-api-gateway%EB%A1%9C-%EC%84%9C%EB%B2%84%EB%A6%AC%EC%8A%A4-%ED%99%98%EA%B2%BD-%EA%B5%AC%EC%84%B1%ED%95%98%EA%B8%B0.html)에.. 위키 첨 써봣는데 어렵네요
- 프로퍼티파일 노션에 업로드 해놨습니다. 편리한 테스트를 위해! 테스트케이스 두가지도 노션 api문서 내에 첨부했습니당 참조해주세여
 
---

### ✨ 참고 사항
- 이미지 좌표를 시계방향(좌상, 우상, 우하, 좌하 순서로) 4개의 점으로 주어야 합니다. 그렇지 않으면 이상하게 잘릴 수 있습니다.
저도 아무 순서로 찍어도 처리되도록 하고 싶었는데, 뭐 그럴 가능성은 적지만 예를 들어 직사각형이 아닌 마름모 형태로 자르고 싶어한다던가 그러면
정확히 어디가 위고 아래이며 이걸 어떻게 다시 직사각형 변환할지 처리가 애매해서 무조건 시계방향 순서로 배열이 와야 헙니다. 그래야 첫번째, 두번째 점을 위로보고 세번째, 네번째 점을 아래로 두어 직사각형 형태의 그림으로 반환할 수 있으니까요!(뭔말인지 이해가 어려우려나..)
클라에서 유저에게 가이드할 때 해당 사항을 화면에 안내해주어야 할 듯 합니다.

- 현재 그림변환 이후 gpt에 넘겨서 문제변환을 해서 이부분을 동시에 처리할 수 있도록 비동기처리 하면 될 듯 합니다!!! 챌린징하자 챌린징
---

### ⏰ 현재 버그

---

### ✏ Git Close #134 
