### PR TITLE
Fix: kakao login 로직 변경

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
@@ -6,12 +6,10 @@ import com.swm_standard.phote.service.GoogleAuthService
 import com.swm_standard.phote.service.KaKaoAuthService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.servlet.view.RedirectView
 
 @RestController
 @RequestMapping("/api/auth")
@@ -20,12 +18,6 @@ class AuthController(
     private val googleAuthService: GoogleAuthService,
     private val kaKaoAuthService: KaKaoAuthService,
 ) {
-    @Value("\${KAKAO_REST_API_KEY}")
-    lateinit var kakaokey: String
-
-    @Value("\${KAKAO_REDIRECT_URI}")
-    lateinit var kakaoRedirectUri: String
-
     @Operation(summary = "google-login", description = "구글 로그인/회원가입")
     @GetMapping("/google-login")
     fun googleLogin(
@@ -40,18 +32,7 @@ class AuthController(
 
     @Operation(summary = "kakao-login", description = "카카오 로그인/회원가입")
     @GetMapping("/kakao-login")
-    fun kakaoLogin(): RedirectView {
-        val redirectView = RedirectView()
-        redirectView.url =
-            "https://kauth.kakao.com/oauth/authorize?response_type=code&" +
-            "client_id=$kakaokey&redirect_uri=$kakaoRedirectUri"
-
-        return redirectView
-    }
-
-    @Operation(summary = "kakao-login", description = "카카오 로그인 유저 정보 조회")
-    @GetMapping("/kakao-token")
-    fun getKakaoUserInfo(
+    fun kakaoLogin(
         @RequestParam code: String,
     ): BaseResponse<UserInfoResponse> {
         val accessToken = kaKaoAuthService.getTokenFromKakao(code)


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- kakao login 작동 방식을 클라이언트에서 authorization code를 전달받아 사용자 정보를 반환하는 것으로 변경했습니다.

---

### ✨ 참고 사항
- 노션, 깃시크릿 모두 프로퍼티파일 업데이트 했습니당
- 구글과 마찬가지로 REDIRECT_URI를 클라이언트 로컬 주소로 설정해야해서 일단은 그렇게 했는데 배포 시에는 클라이언트 배포 도메인 주소로 변경해야합니돵
- 이와 별개로... 왜 ec2 도커에선 레디스가 안돌아갈까요...? ㅠ.ㅠ 로그를 봐도 뭔가 뾰족한 해결방안이 안나오네여..
---

### ⏰ 현재 버그

---

### ✏ Git Close #175 
