### PR TITLE
Feat: receiveSharedWorkbook

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
@@ -125,4 +125,16 @@ class WorkbookController(
 
         return BaseResponse(msg = "문제집의 문제 목록 조회 성공", data = response)
     }
+
+    @Operation(summary = "readQuestionsInWorkbook", description = "문제집 내 문제 목록 조회")
+    @SecurityRequirement(name = "bearer Auth")
+    @PostMapping("/shared-workbook")
+    fun receiveSharedWorkbook(
+        @Valid @RequestBody receiveSharedWorkbookRequest: ReceiveSharedWorkbookRequest,
+        @MemberId memberId: UUID,
+    ): BaseResponse<ReceiveSharedWorkbookResponse> {
+        val response = workbookService.receiveSharedWorkbook(receiveSharedWorkbookRequest, memberId)
+
+        return BaseResponse(data = response, msg = "문제집 공유 받기 성공")
+    }
 }

--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -98,3 +98,11 @@ data class ReadQuestionsInWorkbookResponse(
     val category: Category,
     val tags: List<Tag>,
 )
+
+data class ReceiveSharedWorkbookRequest(
+    val workbookId: UUID
+)
+
+data class ReceiveSharedWorkbookResponse(
+    val id: UUID,
+)

--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -44,7 +44,6 @@ data class Question(
     var tags: MutableList<Tag> = mutableListOf(),
     val memo: String?,
 ) : BaseTimeEntity() {
-
     fun deserializeOptions(): MutableList<String> {
         val optionsList = mutableListOf<String>()
         options!!.fields().forEach { option ->
@@ -52,5 +51,23 @@ data class Question(
         }
 
         return optionsList
+    }
+
+    companion object {
+        fun createSharedQuestions(
+            questions: List<Question>,
+            member: Member,
+        ) = questions.map { question ->
+            Question(
+                member = member,
+                statement = question.statement,
+                options = question.options,
+                answer = question.answer,
+                category = question.category,
+                tags = question.tags,
+                image = question.image,
+                memo = question.memo,
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Workbook.kt
@@ -50,6 +50,16 @@ data class Workbook(
             matchEmojiByTitle(title),
         )
 
+        fun createSharedWorkbook(
+            workbook: Workbook,
+            member: Member,
+        ) = Workbook(
+            "${workbook.title} created by ${workbook.member.name}",
+            workbook.description,
+            member,
+            workbook.emoji,
+        )
+
         private fun matchEmojiByTitle(title: String): String {
             val math: List<String> = listOf("수학", "math", "미적분", "확통", "수1", "수2", "기하", "대수")
             val language: List<String> = listOf("국어", "언매", "화작", "비문학", "문학", "독서", "듣기", "영어", "eng", "토익", "외국")

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -15,6 +15,7 @@ import com.swm_standard.phote.dto.ReceiveSharedWorkbookResponse
 import com.swm_standard.phote.dto.UpdateQuestionSequenceRequest
 import com.swm_standard.phote.dto.UpdateWorkbookDetailRequest
 import com.swm_standard.phote.dto.UpdateWorkbookDetailResponse
+import com.swm_standard.phote.entity.Member
 import com.swm_standard.phote.entity.Question
 import com.swm_standard.phote.entity.QuestionSet
 import com.swm_standard.phote.entity.Workbook
@@ -29,6 +30,7 @@ import java.util.UUID
 import kotlin.jvm.optionals.getOrElse
 
 @Service
+@Transactional(readOnly = true)
 class WorkbookService(
     private val workbookRepository: WorkbookRepository,
     private val memberRepository: MemberRepository,
@@ -40,7 +42,7 @@ class WorkbookService(
         request: CreateWorkbookRequest,
         memberId: UUID,
     ): CreateWorkbookResponse {
-        val member = memberRepository.findById(memberId).orElseThrow { NotFoundException(fieldName = "member") }
+        val member = getMember(memberId)
         val workbook: Workbook =
             Workbook.createWorkbook(request.title, request.description, member).let {
                 workbookRepository.save(it)
@@ -51,16 +53,15 @@ class WorkbookService(
 
     @Transactional
     fun deleteWorkbook(id: UUID): DeleteWorkbookResponse {
-        workbookRepository.findById(id).orElseThrow { NotFoundException("workbookId", "존재하지 않는 workbook") }
+        getWorkbook(id)
 
         workbookRepository.deleteById(id)
 
         return DeleteWorkbookResponse(id, LocalDateTime.now())
     }
 
-    @Transactional(readOnly = true)
     fun readWorkbookDetail(id: UUID): ReadWorkbookDetailResponse {
-        val workbook = workbookRepository.findById(id).getOrElse { throw NotFoundException() }
+        val workbook = getWorkbook(id)
 
         return ReadWorkbookDetailResponse(
             workbook.id,
@@ -72,9 +73,8 @@ class WorkbookService(
         )
     }
 
-    @Transactional(readOnly = true)
     fun readWorkbookList(memberId: UUID): List<ReadWorkbookListResponse> {
-        val member = memberRepository.findById(memberId).getOrElse { throw InvalidInputException("memberId") }
+        val member = getMember(memberId)
         val workbooks: List<Workbook> = workbookRepository.findAllByMember(member)
 
         return workbooks.map { workbook ->
@@ -94,10 +94,7 @@ class WorkbookService(
         workbookId: UUID,
         request: AddQuestionsToWorkbookRequest,
     ) {
-        val workbook: Workbook =
-            workbookRepository
-                .findById(workbookId)
-                .orElseThrow { NotFoundException(fieldName = "workbook", message = "id 를 재확인해주세요.") }
+        val workbook: Workbook = getWorkbook(workbookId)
         var nextSeq = questionSetRepository.findMaxSequenceByWorkbookId(workbook) + 1
         val initialSeq = nextSeq
 
@@ -113,30 +110,12 @@ class WorkbookService(
         workbook.increaseQuantity(nextSeq - initialSeq)
     }
 
-    private fun insertQuestion(
-        question: Question,
-        workbook: Workbook,
-        sequence: Int,
-    ): Int {
-        if (!questionSetRepository
-                .existsByQuestionIdAndWorkbookId(question.id, workbook.id)
-        ) {
-            questionSetRepository.save(QuestionSet.createSequence(question, workbook, sequence))
-            return sequence + 1
-        }
-
-        return sequence
-    }
-
     @Transactional
     fun deleteQuestionInWorkbook(
         workbookId: UUID,
         questionId: UUID,
     ): DeleteQuestionInWorkbookResponse {
-        val workbook =
-            workbookRepository
-                .findById(workbookId)
-                .getOrElse { throw NotFoundException(fieldName = "workbook", message = "id 를 재확인해주세요.") }
+        val workbook = getWorkbook(workbookId)
 
         questionSetRepository.findByQuestionIdAndWorkbookId(questionId, workbookId)?.also {
             questionSetRepository.delete(it)
@@ -154,12 +133,8 @@ class WorkbookService(
         workbookId: UUID,
         request: List<UpdateQuestionSequenceRequest>,
     ): UUID {
-        val workbook: Workbook =
-            workbookRepository
-                .findById(workbookId)
-                .getOrElse { throw NotFoundException(fieldName = "workbook", message = "id를 재확인해주세요.") }
+        val workbook = getWorkbook(workbookId)
 
-        // 질문 : 이런 로직도 비지니스 함수 내부로 넣어야할지
         if (!workbook.compareQuestionQuantity(request.size)) {
             throw InvalidInputException(
                 fieldName = "question",
@@ -184,10 +159,7 @@ class WorkbookService(
         workbookId: UUID,
         request: UpdateWorkbookDetailRequest,
     ): UpdateWorkbookDetailResponse {
-        val workbook: Workbook =
-            workbookRepository
-                .findById(workbookId)
-                .getOrElse { throw NotFoundException(fieldName = "workbook", message = "id를 재확인해주세요.") }
+        val workbook = getWorkbook(workbookId)
 
         workbook.updateWorkbook(request.title, request.description)
 
@@ -195,9 +167,8 @@ class WorkbookService(
     }
 
     fun readQuestionsInWorkbook(workbookId: UUID): List<ReadQuestionsInWorkbookResponse> {
-        workbookRepository
-            .findById(workbookId)
-            .getOrElse { throw InvalidInputException(fieldName = "workbook", message = "id를 재확인해주세요.") }
+        getWorkbook(workbookId)
+
         val questionSets: List<QuestionSet> = questionSetRepository.findByWorkbookIdOrderBySequence(workbookId)
 
         return questionSets.map { set ->
@@ -218,12 +189,8 @@ class WorkbookService(
         request: ReceiveSharedWorkbookRequest,
         memberId: UUID,
     ): ReceiveSharedWorkbookResponse {
-        val workbook =
-            workbookRepository
-                .findById(
-                    request.workbookId,
-                ).getOrElse { throw NotFoundException(fieldName = "workbook") }
-        val member = memberRepository.findById(memberId).getOrElse { throw NotFoundException(fieldName = "member") }
+        val workbook = getWorkbook(request.workbookId)
+        val member = getMember(memberId)
 
         val sharedWorkbook =
             Workbook
@@ -245,5 +212,36 @@ class WorkbookService(
         sharedWorkbook.increaseQuantity(nextSeq)
 
         return ReceiveSharedWorkbookResponse(sharedWorkbook.id)
+    }
+
+    private fun getWorkbook(workbookId: UUID): Workbook {
+        val workbook: Workbook =
+            workbookRepository
+                .findById(workbookId)
+                .orElseThrow { NotFoundException(fieldName = "workbook", message = "id 를 재확인해주세요.") }
+        return workbook
+    }
+
+    private fun getMember(memberId: UUID): Member {
+        val member =
+            memberRepository.findById(memberId).getOrElse {
+                throw InvalidInputException(fieldName = "memberId", message = "id 를 재확인해주세요.")
+            }
+        return member
+    }
+
+    private fun insertQuestion(
+        question: Question,
+        workbook: Workbook,
+        sequence: Int,
+    ): Int {
+        if (!questionSetRepository
+                .existsByQuestionIdAndWorkbookId(question.id, workbook.id)
+        ) {
+            questionSetRepository.save(QuestionSet.createSequence(question, workbook, sequence))
+            return sequence + 1
+        }
+
+        return sequence
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -235,8 +235,7 @@ class WorkbookService(
         workbook: Workbook,
         sequence: Int,
     ): Int {
-        if (!questionSetRepository
-                .existsByQuestionIdAndWorkbookId(question.id, workbook.id)
+        if (!questionSetRepository.existsByQuestionIdAndWorkbookId(question.id, workbook.id)
         ) {
             questionSetRepository.save(QuestionSet.createSequence(question, workbook, sequence))
             return sequence + 1


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 공유받은 문제집을 내부 문제 목록과 함께 저장하는 기능을 구현했습니다.
- 처음에 pathparam으로 구현했다가 uuid는 최대한 외부 노출을 피하는 편이 좋을 것 같아서(더하여 타인의 문제집 uuid이다보니) request body로 받는걸로 변경했습니다!

- WorkbookService에서 `getMember()`, `getWorbook()` 으로 extract했습니다.
- 문제를 문제집에 추가하는 동작을 `receiveSharedWorkbook`, `addQuestionsToWorkbook` 에서 모두 하므로, `insertQuestion()` 로  extract했습니다.

---

### ✨ 참고 사항

- 기능 구현 관련 커밋은 191e601e6d8a1fc68fbbc9583711ef2ac9d36c1c 입니다!
- fixture monkey는 의존성 추가해서 사용하던 중에 Workbook 을 목으로 생성했는데 거기에 딸려있는 태그가 null 로 들어가는 오류가 있어서 원래 그런건가... 하고 검색해보니 마침 해당 오픈소스에서 따끈따끈한 에러가 발생했더라구요... 그래서 일단 이번 테스트에는 포함하지 않았습니다. 해당 오류가 해결되면 도입해보겠습니다.


---

### ⏰ 현재 버그

x
- 다만 문제집 내 문제를 모두 복사하여 새로 저장해야하므로 현재 사용중인 jpa의 `saveAll()` 메서드 대신 배치 세이브 방식을 사용해서 성능을 개선해볼까합니다.

---

### ✏ Git Close
- #163 
