### PR TITLE
 Fix: 노출 불필요한 modifiedAt, createdAt 필터링하기

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
@@ -1,6 +1,7 @@
 package com.swm_standard.phote.dto
 
 import com.swm_standard.phote.entity.Category
+import java.time.LocalDateTime
 import java.util.UUID
 
 data class ReadExamHistoryDetail(
@@ -19,6 +20,7 @@ data class ReadExamHistoryDetailResponse(
     val totalCorrect: Int,
     val time: Int,
     val questions: List<ReadExamHistoryDetail>,
+    val createdAt: LocalDateTime,
 )
 
 data class ReadExamHistoryListResponse(

--- a/src/main/kotlin/com/swm_standard/phote/entity/BaseTimeEntity.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/BaseTimeEntity.kt
@@ -14,9 +14,11 @@ import java.time.LocalDateTime
 abstract class BaseTimeEntity {
     @CreatedDate
     @Column(updatable = false)
+    @JsonIgnore
     var createdAt: LocalDateTime = LocalDateTime.now()
 
     @LastModifiedDate
+    @JsonIgnore
     var modifiedAt: LocalDateTime? = null
 
     @JsonIgnore

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -67,6 +67,7 @@ class ExamService(
             totalCorrect = exam.totalCorrect,
             time = exam.time,
             questions = responses,
+            createdAt = exam.createdAt,
         )
     }
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- BaseTimeEntity 를 따로 빼면서 Tag 엔티티 등에서  노출 불필요한 modifiedAt, createdAt  를 필터링했습니다.
- modifiedAt 필드가 필요한 데이터들은 dto에서 해당 필드를 수동 지정하므로, Tag 응답을 위한 dto를 따로 만드는 대신 BaseTimeEntity의 세 필드를 모두 `@JsonIgnore` 처리했습니다. 

---

### ✨ 참고 사항]

- 구현 후 테스트하면서 시험 기록  상세 조회 (readExamHistoryDetail) 기능에서 response body에 `createdAt` 필드가 있는 것이 좋을 것 같아 추가했습니다. 추가 여부는 @RinRinPARK 님이 정해주시면 추가하거나 원복하겠습니다!

---

### ⏰ 현재 버그

x

---

### ✏ Git Close

- #178 