### PR TITLE
Refactor: gradeExam 비동기 처리

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
     implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0-RC")
 
     // querydsl
     implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")

--- a/src/main/kotlin/com/swm_standard/phote/entity/Answer.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Answer.kt
@@ -41,16 +41,7 @@ data class Answer(
         )
     }
 
-    /**
-     * 객관식 문제면 정오답 체크를 하고 true 반환,
-     * 주관식 문제면 정오답 여부 판별 없이 false 반환 -> ChatGPT를 이용해야 하기 때문
-     **/
-    fun isMultipleAndCheckAnswer(): Boolean {
-        if (question.category == Category.MULTIPLE) {
-            isCorrect = submittedAnswer == question.answer
-            return true
-        } else {
-            return false
-        }
+    fun checkMultipleAnswer() {
+        isCorrect = submittedAnswer == question.answer
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -33,6 +33,7 @@ import java.util.UUID
 import kotlin.jvm.optionals.getOrElse
 
 @Service
+@Transactional(readOnly = true)
 class ExamService(
     private val examRepository: ExamRepository,
     private val questionRepository: QuestionRepository,
@@ -47,7 +48,6 @@ class ExamService(
     @Value("\${openai.api.url}")
     lateinit var url: String
 
-    @Transactional(readOnly = true)
     fun readExamHistoryDetail(id: UUID): ReadExamHistoryDetailResponse {
         val exam = examRepository.findById(id).orElseThrow { NotFoundException("examId", "존재하지 않는 examId") }
 
@@ -77,7 +77,6 @@ class ExamService(
         )
     }
 
-    @Transactional(readOnly = true)
     fun readExamHistoryList(workbookId: UUID): List<ReadExamHistoryListResponse> {
         val exams = examRepository.findAllByWorkbookId(workbookId)
         return exams.map { exam ->

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -19,8 +19,8 @@ import com.swm_standard.phote.repository.ExamRepository
 import com.swm_standard.phote.repository.MemberRepository
 import com.swm_standard.phote.repository.QuestionRepository
 import com.swm_standard.phote.repository.WorkbookRepository
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -132,7 +132,7 @@ class ExamService(
                         sequence = index + 1,
                     )
 
-                GlobalScope.launch(Dispatchers.IO) {
+                CoroutineScope(Dispatchers.IO).launch {
                     if (savingAnswer.submittedAnswer == null) {
                         savingAnswer.isCorrect = false
                     } else {

--- a/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
@@ -48,23 +48,23 @@ class AnswerTest {
         correctAnswer: String,
     ) = Answer(
         question =
-            Question(
-                id = UUID.randomUUID(),
-                member =
-                    Member(
-                        name = "Erik Ashley",
-                        email = "jay.combs@example.com",
-                        image = "per",
-                        provider = Provider.APPLE,
-                    ),
-                statement = "Kentucky",
-                options = null,
-                image = null,
-                answer = correctAnswer,
-                category = category,
-                questionSet = listOf(),
-                memo = null,
+        Question(
+            id = UUID.randomUUID(),
+            member =
+            Member(
+                name = "Erik Ashley",
+                email = "jay.combs@example.com",
+                image = "per",
+                provider = Provider.APPLE,
             ),
+            statement = "Kentucky",
+            options = null,
+            image = null,
+            answer = correctAnswer,
+            category = category,
+            questionSet = listOf(),
+            memo = null,
+        ),
         exam = createExam(),
         submittedAnswer = submittedAnswer,
         sequence = 2017,

--- a/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
@@ -6,40 +6,15 @@ import java.util.UUID
 
 class AnswerTest {
     @Test
-    fun `문제가 객관식이면 정오답 체크를 하고 틀릴 경우 isCorrect가 false가 된다`() {
+    fun `문제가 객관식이면 정오답 체크한다`() {
         val category = Category.MULTIPLE
         val submittedAnswer = "1"
         val correctAnswer = "5"
         val answer = createAnswer(category, submittedAnswer, correctAnswer)
 
-        val checkAnswer = answer.isMultipleAndCheckAnswer()
+        answer.checkMultipleAnswer()
 
-        Assertions.assertTrue(checkAnswer)
-        Assertions.assertFalse(answer.isCorrect)
-    }
-
-    @Test
-    fun `문제가 주관식이면 false를 반환한다`() {
-        val category = Category.ESSAY
-        val submittedAnswer = "essay test"
-        val correctAnswer = "essay test"
-        val answer = createAnswer(category, submittedAnswer, correctAnswer)
-
-        val checkAnswer = answer.isMultipleAndCheckAnswer()
-
-        Assertions.assertFalse(checkAnswer)
-    }
-
-    @Test
-    fun `답안이 null이면 isCorrect는 false로 체크한다`() {
-        val category = Category.MULTIPLE
-        val submittedAnswer = null
-        val correctAnswer = "5"
-        val answer = createAnswer(category, submittedAnswer, correctAnswer)
-
-        val checkAnswer = answer.isMultipleAndCheckAnswer()
-
-        Assertions.assertTrue(checkAnswer)
+        Assertions.assertEquals(submittedAnswer == correctAnswer, answer.isCorrect)
         Assertions.assertFalse(answer.isCorrect)
     }
 
@@ -73,23 +48,23 @@ class AnswerTest {
         correctAnswer: String,
     ) = Answer(
         question =
-        Question(
-            id = UUID.randomUUID(),
-            member =
-            Member(
-                name = "Erik Ashley",
-                email = "jay.combs@example.com",
-                image = "per",
-                provider = Provider.APPLE,
+            Question(
+                id = UUID.randomUUID(),
+                member =
+                    Member(
+                        name = "Erik Ashley",
+                        email = "jay.combs@example.com",
+                        image = "per",
+                        provider = Provider.APPLE,
+                    ),
+                statement = "Kentucky",
+                options = null,
+                image = null,
+                answer = correctAnswer,
+                category = category,
+                questionSet = listOf(),
+                memo = null,
             ),
-            statement = "Kentucky",
-            options = null,
-            image = null,
-            answer = correctAnswer,
-            category = category,
-            questionSet = listOf(),
-            memo = null,
-        ),
         exam = createExam(),
         submittedAnswer = submittedAnswer,
         sequence = 2017,


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- coroutine을 이용해 gradeExam 에서 ChatGPT 요청을 보내는 부분을 비동기 처리했습니다.
- 또한 모호한 `isMultipleAndCheckAnswer()` 을 제거하고 대신 카테고리 체크는 서비스 클래스에서 하도록 해서 `checkMultipleAnswer()` 메서드를 생성했습니다.
    - 메서드가 변경되면서 유닛테스트 코드도 이에 맞게 변경했습니다. 
- 공통으로 사용하는 `@Transactional(readOnly = true)` 을 클래스 상단으로 이동시켰습니다.

---

### ✨ 참고 사항

- 상세한 작업 내용은 [💬wiki - Coroutine 으로 비동기 처리하기](https://swm-standard.github.io/phote-wiki/coroutine-%EC%9C%BC%EB%A1%9C-%EB%B9%84%EB%8F%99%EA%B8%B0-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0.html) 를 참고해주세요!

---

### ⏰ 현재 버그

- kotlinx-coroutines-core 라이브러리는 최신 코틀린 버전을 사용해야한다고 해서 version "2.0.0" 으로 바꿨더니 KtLint 도 함께 최신 버전으로 바꿔줘야했습니다. 그렇게 하니 editorconfig 로 disable 했던 규칙들이 다시 살아나서 package-naming 오류를 해결할 수가 없었습니다. 따라서 일단 코틀린 버전을 이전과 그대로 유지해둔 상태이고 다행히 정상 작동하긴 합니다!
    - 코틀린 버전을 업그레이드하게 된다면 아예 package-naming 규칙에 맞게 `swm_standard` 패키지 명에서 언더스코어를 빼도 될 것 같습니다.

---

### ✏ Git Close
- #180 
