### PR TITLE
Fix: kakao login redirect uri request로 요청 & POST 메소드로 변경

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
@@ -1,6 +1,7 @@
 package com.swm_standard.phote.controller
 
 import com.swm_standard.phote.common.responsebody.BaseResponse
+import com.swm_standard.phote.dto.LoginRequest
 import com.swm_standard.phote.dto.RenewAccessTokenResponse
 import com.swm_standard.phote.dto.UserInfoResponse
 import com.swm_standard.phote.service.GoogleAuthService
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -37,11 +39,11 @@ class AuthController(
     }
 
     @Operation(summary = "kakao-login", description = "카카오 로그인/회원가입")
-    @GetMapping("/kakao-login")
+    @PostMapping("/kakao-login")
     fun kakaoLogin(
-        @RequestParam code: String,
+        @RequestBody request: LoginRequest
     ): BaseResponse<UserInfoResponse> {
-        val accessToken = kaKaoAuthService.getTokenFromKakao(code)
+        val accessToken = kaKaoAuthService.getTokenFromKakao(request)
         val userInfo = kaKaoAuthService.getUserInfoFromKakao(accessToken)
 
         val message = if (userInfo.isMember == false) "회원가입 성공" else "로그인 성공"

--- a/src/main/kotlin/com/swm_standard/phote/dto/AuthDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/AuthDtos.kt
@@ -30,3 +30,8 @@ data class UserInfoResponse(
 data class RenewAccessTokenResponse(
     val accessToken: String,
 )
+
+data class LoginRequest(
+    val code: String,
+    val redirectUri: String,
+)

--- a/src/main/kotlin/com/swm_standard/phote/service/KaKaoAuthService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/KaKaoAuthService.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.swm_standard.phote.common.authority.JwtTokenProvider
 import com.swm_standard.phote.common.module.NicknameGenerator
 import com.swm_standard.phote.common.module.ProfileImageGenerator
+import com.swm_standard.phote.dto.LoginRequest
 import com.swm_standard.phote.dto.UserInfoResponse
 import com.swm_standard.phote.entity.Member
 import com.swm_standard.phote.entity.Provider
@@ -26,18 +27,15 @@ class KaKaoAuthService(
     @Value("\${KAKAO_REST_API_KEY}")
     lateinit var kakaokey: String
 
-    @Value("\${KAKAO_REDIRECT_URI}")
-    lateinit var kakaoRedirectUri: String
-
-    fun getTokenFromKakao(code: String): String {
+    fun getTokenFromKakao(request: LoginRequest): String {
         val headers = HttpHeaders()
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8")
 
         val body: MultiValueMap<String, String> = LinkedMultiValueMap()
         body.add("grant_type", "authorization_code")
         body.add("client_id", kakaokey)
-        body.add("redirect_uri", kakaoRedirectUri)
-        body.add("code", code)
+        body.add("redirect_uri", request.redirectUri)
+        body.add("code", request.code)
 
         val kakaoTokenRequest = HttpEntity(body, headers)
         val response =


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- kakao login에서 redirect uri를 클라에서 request로 보내주는 것으로 변경했습니다.
- HTTP 메소드를 POST로 변경했습니다. 흠 기존에 왜 GET으로 하고 이상함을 알아차리지 못했을까요?ㅋㅋ 이제라도.. 변경해봤슴다ㅎ

---

### ✨ 참고 사항
- GET 요청은 캐싱 때문에 보안이 약해 로그인에선 주로 POST를 사용하는 것으로 알고 있스무니다.
---

### ⏰ 현재 버그

---

### ✏ Git Close #190 
