### PR TITLE
Fix: Google Login redirect uri request로 요청

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
@@ -9,12 +9,10 @@ import com.swm_standard.phote.service.KaKaoAuthService
 import com.swm_standard.phote.service.TokenService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -27,11 +25,11 @@ class AuthController(
     private val tokenService: TokenService,
 ) {
     @Operation(summary = "google-login", description = "구글 로그인/회원가입")
-    @GetMapping("/google-login")
+    @PostMapping("/google-login")
     fun googleLogin(
-        @RequestParam code: String,
+        @RequestBody request: LoginRequest,
     ): BaseResponse<UserInfoResponse> {
-        val accessToken = googleAuthService.getTokenFromGoogle(code)
+        val accessToken = googleAuthService.getTokenFromGoogle(request)
         val userInfo = googleAuthService.getUserInfoFromGoogle(accessToken)
 
         val message = if (userInfo.isMember == false) "회원가입 성공" else "로그인 성공"
@@ -41,7 +39,7 @@ class AuthController(
     @Operation(summary = "kakao-login", description = "카카오 로그인/회원가입")
     @PostMapping("/kakao-login")
     fun kakaoLogin(
-        @RequestBody request: LoginRequest
+        @RequestBody request: LoginRequest,
     ): BaseResponse<UserInfoResponse> {
         val accessToken = kaKaoAuthService.getTokenFromKakao(request)
         val userInfo = kaKaoAuthService.getUserInfoFromKakao(accessToken)

--- a/src/main/kotlin/com/swm_standard/phote/service/GoogleAuthService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/GoogleAuthService.kt
@@ -4,6 +4,7 @@ import com.swm_standard.phote.common.authority.JwtTokenProvider
 import com.swm_standard.phote.common.module.NicknameGenerator
 import com.swm_standard.phote.common.module.ProfileImageGenerator
 import com.swm_standard.phote.dto.GoogleAccessResponse
+import com.swm_standard.phote.dto.LoginRequest
 import com.swm_standard.phote.dto.UserInfoResponse
 import com.swm_standard.phote.entity.Member
 import com.swm_standard.phote.entity.Provider
@@ -27,10 +28,7 @@ class GoogleAuthService(
     @Value("\${GOOGLE_CLIENT_SECRET}")
     lateinit var clientSecret: String
 
-    @Value("\${REDIRECT_URI}")
-    lateinit var redirectUri: String
-
-    fun getTokenFromGoogle(code: String): String {
+    fun getTokenFromGoogle(request: LoginRequest): String {
         val restTemplate = RestTemplate()
         val headers = HttpHeaders()
         val params: MutableMap<String, Any> = HashMap()
@@ -40,7 +38,8 @@ class GoogleAuthService(
             restTemplate
                 .exchange(
                     "https://oauth2.googleapis.com/token?grant_type=authorization_code&" +
-                        "client_id=$clientId&client_secret=$clientSecret&code=$code&redirect_uri=$redirectUri",
+                        "client_id=$clientId&client_secret=$clientSecret&code=${request.code}" +
+                        "&redirect_uri=${request.redirectUri}",
                     HttpMethod.POST,
                     googleTokenRequest,
                     GoogleAccessResponse::class.java,


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- Google Login 에서 redirect uri를 request body에 담는 것으로 변경했습니다.
- POST 요청으로 변경했습니다.

---

### ✨ 참고 사항

- 미사용 구글 redirect uri 는 프로퍼티 파일에서 삭제 후 노션, 깃헙 시크릿에 반영해뒀습니다.

---

### ⏰ 현재 버그

x

---

### ✏ Git Close
- #192 
