### PR TITLE
Fix: readQuestionsInWorkbook 의 options 형식 변경

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/WorkbookDtos.kt
@@ -1,7 +1,6 @@
 package com.swm_standard.phote.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.JsonNode
 import com.swm_standard.phote.entity.Category
 import com.swm_standard.phote.entity.Tag
 import jakarta.validation.constraints.NotBlank
@@ -93,14 +92,14 @@ data class ReadQuestionsInWorkbookResponse(
     val questionSetId: UUID,
     val questionId: UUID,
     val statement: String,
-    val options: JsonNode?,
+    val options: List<String>?,
     val image: String?,
     val category: Category,
     val tags: List<Tag>,
 )
 
 data class ReceiveSharedWorkbookRequest(
-    val workbookId: UUID
+    val workbookId: UUID,
 )
 
 data class ReceiveSharedWorkbookResponse(

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -176,7 +176,7 @@ class WorkbookService(
                 set.id,
                 set.question.id,
                 set.question.statement,
-                set.question.options,
+                set.question.options?.let { set.question.deserializeOptions() },
                 set.question.image,
                 set.question.category,
                 set.question.tags,


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

-  `readQuestionsInWorkbook` 의 options 형식을 다른 api와 동일하게 배열로 변경했습니다.

---

### ✨ 참고 사항

x

---

### ⏰ 현재 버그

x

---

### ✏ Git Close

- #194 
