### PR TITLE
Refactor: transformQuestion 리팩토링

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0-RC")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.9.0-RC")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
 
     // querydsl
     implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
     implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0-RC")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.9.0-RC")
 
     // querydsl
     implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")

--- a/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/QuestionController.kt
@@ -90,10 +90,11 @@ class QuestionController(
     @Operation(summary = "transformQuestion", description = "문제 변환")
     @SecurityRequirement(name = "bearer Auth")
     @PostMapping("question-transform")
-    fun transformQuestion(
+    suspend fun transformQuestion(
         @RequestPart image: MultipartFile?,
         @RequestPart imageCoordinates: List<List<Int>>? = null,
     ): BaseResponse<TransformQuestionResponse> {
+
         val imageUrl = image?.let { s3Service.uploadChatGptImage(it) }
         val response: TransformQuestionResponse = questionService.transformQuestion(imageUrl!!, imageCoordinates)
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- transformQuestion 부분을 리팩토링 하여 runBlocking을 삭제했습니다!! (사유: 지난 멘토링 때 runBlocking은 메인 스레드를 차단하여 다른 요청이 들어왔을 때 스레드가 차지되어 있으면 사용하지 못할 가능성이 있으므로 다른걸로 변경하는게 좋겠다 + 요청이 아주 많이 들어왔을 때 문제가 생길 수 있다는 멘토님의 조언..)
- transfromQuestion controller를 suspend함수로 바꾸었습니당당이. service로직에서 코루틴을 사용하여 suspend함수로 바꿔주지 않으면 오류가 납니더이. 근데 controller에 suspend를 붙여주려면 webflux를 사용해야해서.. 디펜던시에 ` kotlinx-coroutines-reactor `를 추가했읍니당(코틀린 코루틴과 스프링 리액터 및 웹플럭스를 함께 사용할 수 있는 디펜던시!)
- 기존에 RestTemplate으로 람다함수에 보내던 요청을 WebClient로 변경했습니다. RestTemplate은 동기적 요청인 반면에 WebClient는 비동기 요청이 가능하다고 하드라구용. 비동기적 처리를 위해 코루틴을 도입한 만큼 WebClient로 변경하는게 목적에 맞을 것 같아서 해보았습니다. 다만, 은근.. WebClient가 어려운 개념이더라고요? 머쓱;

---

### ✨ 참고 사항
- ` kotlinx-coroutines-reactor `가 코틀린 코루틴과 스프링 리액터 및 웹플럭스를 함께 사용할 수 있는 디펜던시라고 해놓고 `spring-boot-starter-webflux` 이건 왜 추가 했는지 궁금할 수 있을 것 같슴다. 
WebClient가 webflux에 붙어 있어서 WebClient를 사용하려면 웹플럭스를 붙여야 하는데용, 저도 첨에 전자만 붙이고 WebClient를 써볼라고 하니까 안불러와지더라구요. 아마 전자는 웹플럭스 기능까지 다 불러오는게 아니라 ` 코루틴과 스프링 리액터 및 웹플럭스를 "함께" 사용할 수 있도록 `하는 것이 아닌가 합니다. kotlinx-coroutines-reactor에 대한 정보가 찾아봐도 딱히 안나와서.. 뇌피셜입니다.
---

### ⏰ 현재 버그

---

### ✏ Git Close #198 
