### PR TITLE
Fix: jacoco test Report 불필요 클래스 제외

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -34,7 +34,7 @@ jobs:
               run: chmod +x gradlew
 
             - name: Test with Gradle
-              run: ./gradlew clean build test jacocoTestReport
+              run: ./gradlew clean build test
 
             - name: Publish Unit Test Results
               uses: EnricoMi/publish-unit-test-result-action@v1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,6 +142,9 @@ kapt {
 }
 
 tasks.jacocoTestReport {
+
+    dependsOn(tasks.test)
+
     reports {
         html.required.set(true)
         xml.required.set(true)


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- #200   이슈에 이어서 `jacocoTestReport` 에 표시될 필요가 없는 `entity 패키지 외의 클래스들`, queryDSL 을 위한 `Q~ 클래스` 를 제외했습니다.
- 또한 앞으로 테스트 커버리지를 어느정도 보장하면서 개발을 하고자 `jacocoTestCoverageVerification` 에서도 위와 동일하게 클래스들을 제외했습니다. ➡️ 제외하지 않을 경우 쓸데 없는 모든 클래스의 테스트를 해야할 수 있기 때문

---

### ✨ 참고 사항

- 아직 `QuestionSet` 등 테스트를 진행하지 않은 클래스가 있기 때문에 브랜치 커버리지, 메서드 커버리지 모두 0 으로 설정해뒀습니다. 조만간 **필요한 테스트코드를 모두 작성한 후에 커버리지 퍼센티지를 정해야** 할 것 같습니당!

- build.gradle 내의 태스크들 간의 실행 프로세스를 지정했기 때문에 `develop-ci.yml`  37번 줄에서 `run: ./gradlew clean build test jacocoTestReport` 을 `run: ./gradlew clean build test` 로 변경했습니다.

#### 🙋 변경 전
<img width="500" alt="스크린샷 2024-09-02 오후 11 43 01" src="https://github.com/user-attachments/assets/06a95057-fced-44bf-8c13-e49e2f7df24b">

#### 🙋 변경 후 
<img width="500" alt="스크린샷 2024-09-04 오후 2 12 12" src="https://github.com/user-attachments/assets/1d1feda3-e675-4783-a3d8-828ebac10802">


---

### ⏰ 현재 버그

x

---

### ✏ Git Close

- #202 
