### PR TITLE
Test: jacoco test coverage에 맞게 테스트 코드 작성

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -34,7 +34,7 @@ jobs:
               run: chmod +x gradlew
 
             - name: Test with Gradle
-              run: ./gradlew clean build test
+              run: ./gradlew clean build jacocoTestReport
 
             - name: Publish Unit Test Results
               uses: EnricoMi/publish-unit-test-result-action@v1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0-RC")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.9.0-RC")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
+    testImplementation("com.navercorp.fixturemonkey:fixture-monkey-kotlin:1.0.23")
 
     // querydsl
     implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
@@ -190,13 +191,13 @@ tasks.jacocoTestCoverageVerification {
             limit {
                 counter = "BRANCH"
                 value = "COVEREDRATIO"
-                minimum = 0.00.toBigDecimal()
+                minimum = 0.40.toBigDecimal()
             }
 
             limit {
                 counter = "METHOD"
                 value = "COVEREDRATIO"
-                minimum = 0.00.toBigDecimal()
+                minimum = 0.40.toBigDecimal()
             }
 
             val qDomains = emptyList<String>().toMutableList()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,7 +91,6 @@ kotlin {
 
 tasks.withType<Test> {
     useJUnitPlatform()
-    finalizedBy("jacocoTestReport")
 }
 
 tasks.test {
@@ -112,17 +111,6 @@ buildscript {
         classpath("org.jlleitschuh.gradle:ktlint-gradle:11.1.0")
     }
 }
-
-// sentry {
-// 	// Generates a JVM (Java, Kotlin, etc.) source bundle and uploads your source code to Sentry.
-// 	// This enables source context, allowing you to see your source
-// 	// code as part of your stack traces in Sentry.
-// 	includeSourceContext = true
-//
-// 	org = "swm-standard"
-// 	projectName = "phote"
-// 	authToken ="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"
-// }
 
 // Querydsl
 val generated = file("src/main/generated")
@@ -172,6 +160,7 @@ tasks.jacocoTestReport {
             "**/repository/*",
             "**/common/*",
             "**/*PhoteApplication*",
+            "**/entity/*RefreshToken*",
         ) + qDomains
 
     classDirectories.setFrom(
@@ -191,7 +180,7 @@ tasks.jacocoTestCoverageVerification {
             limit {
                 counter = "BRANCH"
                 value = "COVEREDRATIO"
-                minimum = 0.40.toBigDecimal()
+                minimum = 0.50.toBigDecimal()
             }
 
             limit {
@@ -216,6 +205,7 @@ tasks.jacocoTestCoverageVerification {
                     "**.repository.*",
                     "**.common.*",
                     "**.*PhoteApplication*",
+                    "**.entity.*RefreshToken*",
                 ) + qDomains
         }
     }

--- a/src/main/kotlin/com/swm_standard/phote/common/module/Qualifier.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/module/Qualifier.kt
@@ -1,0 +1,8 @@
+package com.swm_standard.phote.common.module
+
+class Qualifier {
+    @MustBeDocumented
+    @Retention(AnnotationRetention.RUNTIME)
+    @Target(AnnotationTarget.TYPE, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
+    annotation class Generated
+}

--- a/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/QuestionSet.kt
@@ -33,7 +33,7 @@ data class QuestionSet(
     }
 
     companion object {
-        fun createSequence(
+        fun createQuestionSet(
             question: Question,
             workbook: Workbook,
             nextSequence: Int,

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -237,7 +237,7 @@ class WorkbookService(
     ): Int {
         if (!questionSetRepository.existsByQuestionIdAndWorkbookId(question.id, workbook.id)
         ) {
-            questionSetRepository.save(QuestionSet.createSequence(question, workbook, sequence))
+            questionSetRepository.save(QuestionSet.createQuestionSet(question, workbook, sequence))
             return sequence + 1
         }
 

--- a/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/AnswerTest.kt
@@ -1,10 +1,19 @@
 package com.swm_standard.phote.entity
 
-import org.junit.jupiter.api.Assertions
+import com.navercorp.fixturemonkey.FixtureMonkey
+import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
+import com.navercorp.fixturemonkey.kotlin.giveMeOne
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
 class AnswerTest {
+    private val fixtureMonkey: FixtureMonkey =
+        FixtureMonkey
+            .builder()
+            .plugin(KotlinPlugin())
+            .build()
+
     @Test
     fun `문제가 객관식이면 정오답 체크한다`() {
         val category = Category.MULTIPLE
@@ -14,29 +23,41 @@ class AnswerTest {
 
         answer.checkMultipleAnswer()
 
-        Assertions.assertEquals(submittedAnswer == correctAnswer, answer.isCorrect)
-        Assertions.assertFalse(answer.isCorrect)
+        Assertions.assertThat(submittedAnswer == correctAnswer).isEqualTo(answer.isCorrect)
+        Assertions.assertThat(answer.isCorrect).isFalse()
+    }
+
+    @Test
+    fun `제출한 답안을 생성한다`() {
+        val exam = createExam()
+        val submittedAnswer = "1"
+        val question = createQuestion(answer = submittedAnswer)
+        val sequence = 2
+
+        val createAnswer =
+            Answer.createAnswer(
+                question = question,
+                exam = exam,
+                submittedAnswer = submittedAnswer,
+                sequence = sequence,
+            )
+
+        Assertions.assertThat(createAnswer.submittedAnswer).isEqualTo(submittedAnswer)
+        Assertions.assertThat(createAnswer.exam).isEqualTo(exam)
+        Assertions.assertThat(createAnswer.sequence).isEqualTo(sequence)
     }
 
     fun createWorkbook(): Workbook =
         Workbook(
             title = "hinc",
             description = null,
-            member = createMember(),
+            member = fixtureMonkey.giveMeOne(),
             emoji = "📚",
-        )
-
-    fun createMember(): Member =
-        Member(
-            name = "Mayra Payne",
-            email = "penelope.mccarty@example.com",
-            image = "dicant",
-            provider = Provider.APPLE,
         )
 
     fun createExam() =
         Exam(
-            member = createMember(),
+            member = fixtureMonkey.giveMeOne(),
             workbook = createWorkbook(),
             sequence = 4282,
             time = 40,
@@ -69,4 +90,24 @@ class AnswerTest {
         submittedAnswer = submittedAnswer,
         sequence = 2017,
     )
+
+    private fun createQuestion(answer: String) =
+        Question(
+            id = UUID.randomUUID(),
+            member =
+            Member(
+                name = "Charmaine Joseph",
+                email = "dorothea.avila@example.com",
+                image = "maiorum",
+                provider = Provider.APPLE,
+            ),
+            statement = "Missouri",
+            options = null,
+            image = null,
+            answer = answer,
+            category = Category.MULTIPLE,
+            questionSet = listOf(),
+            tags = mutableListOf(),
+            memo = null,
+        )
 }

--- a/src/test/kotlin/com/swm_standard/phote/entity/ExamTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/ExamTest.kt
@@ -63,7 +63,7 @@ class ExamTest {
         val exam = Exam.createExam(member, workbook, sequence, time)
 
         Assertions.assertThat(exam.workbook).isEqualTo(workbook)
-        Assertions.assertThat(exam.member).isEqualTo(member)
+        Assertions.assertThat(exam.member.name).isEqualTo(member.name)
         Assertions.assertThat(exam.sequence).isEqualTo(sequence)
     }
 

--- a/src/test/kotlin/com/swm_standard/phote/entity/QuestionSetTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/QuestionSetTest.kt
@@ -24,7 +24,7 @@ class QuestionSetTest {
 
     @Test
     fun `questionSet을 생성하는데 성공한다`() {
-        val question = fixtureMonkey.giveMeOne(Question::class.java)
+        val question = createQuestion()
         val workbook = fixtureMonkey.giveMeOne(Workbook::class.java)
         val newSequence = 1
 
@@ -39,4 +39,14 @@ class QuestionSetTest {
         assertEquals(workbook, questionSet.workbook)
         assertEquals(question, questionSet.question)
     }
+
+    private fun createQuestion(): Question =
+        Question(
+            member = Member("phote", "phote@test.com", "image", Provider.KAKAO),
+            statement = "모든 각이 동일한 삼각형은?",
+            image = "http://example.com/image.jpg",
+            answer = "정삼각형",
+            category = Category.ESSAY,
+            memo = "삼각형 내각의 합은 180도이다.",
+        )
 }

--- a/src/test/kotlin/com/swm_standard/phote/entity/QuestionSetTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/QuestionSetTest.kt
@@ -1,0 +1,42 @@
+package com.swm_standard.phote.entity
+
+import com.navercorp.fixturemonkey.FixtureMonkey
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class QuestionSetTest {
+    private val fixtureMonkey: FixtureMonkey =
+        FixtureMonkey
+            .builder()
+            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+            .build()
+
+    @Test
+    fun `questionSet의 순서를 변경하는데 성공한다`() {
+        val questionSet = fixtureMonkey.giveMeOne(QuestionSet::class.java)
+        val newSequence = 4
+
+        questionSet.updateSequence(newSequence)
+
+        assertEquals(newSequence, questionSet.sequence)
+    }
+
+    @Test
+    fun `questionSet을 생성하는데 성공한다`() {
+        val question = fixtureMonkey.giveMeOne(Question::class.java)
+        val workbook = fixtureMonkey.giveMeOne(Workbook::class.java)
+        val newSequence = 1
+
+        val questionSet =
+            QuestionSet.createQuestionSet(
+                question = question,
+                workbook = workbook,
+                nextSequence = newSequence,
+            )
+
+        assertEquals(newSequence, questionSet.sequence)
+        assertEquals(workbook, questionSet.workbook)
+        assertEquals(question, questionSet.question)
+    }
+}

--- a/src/test/kotlin/com/swm_standard/phote/entity/QuestionTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/QuestionTest.kt
@@ -4,12 +4,10 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.navercorp.fixturemonkey.FixtureMonkey
 import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
-import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
 import com.navercorp.fixturemonkey.kotlin.giveMeOne
-import com.navercorp.fixturemonkey.kotlin.size
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import kotlin.test.assertNotNull
+import java.util.UUID
 
 class QuestionTest {
     private val fixtureMonkey: FixtureMonkey =
@@ -39,6 +37,32 @@ class QuestionTest {
             answer = "1",
             category = Category.MULTIPLE,
             memo = "삼각형은 꼭짓점이 3개다",
+            tags =
+            mutableListOf(
+                Tag(
+                    id = 1,
+                    name = "수학",
+                    question =
+                    Question(
+                        id = UUID.randomUUID(),
+                        member =
+                        Member(
+                            name = "Luella Kline",
+                            email = "logan.houston@example.com",
+                            image = "et",
+                            provider = Provider.APPLE,
+                        ),
+                        statement = "Louisiana",
+                        options = null,
+                        image = null,
+                        answer = "hac",
+                        category = Category.MULTIPLE,
+                        questionSet = listOf(),
+                        tags = mutableListOf(),
+                        memo = null,
+                    ),
+                ),
+            ),
         )
     }
 
@@ -57,18 +81,16 @@ class QuestionTest {
 
     @Test
     fun `공유받은 문제를 복사해서 저장한다`() {
-        val questions = fixtureMonkey.giveMeBuilder<Question>().size(Question::tags, 0).sampleList(5)
+        val questions = listOf(createQuestion(), createQuestion(), createQuestion())
+        // val questions = fixtureMonkey.giveMeBuilder<Question>().size(Question::tags, 0).sampleList(5)
         val member: Member = fixtureMonkey.giveMeOne()
-
-        assertNotNull(questions[0])
-
-        println("fixtureMonkey = ${questions[0]}")
 
         val sharedQuestions = Question.createSharedQuestions(questions, member)
 
         assertEquals(sharedQuestions.size, questions.size)
         assertEquals(sharedQuestions[0].member, member)
-        assertEquals(sharedQuestions[1].category, questions[1].category)
         assertEquals(sharedQuestions[2].answer, questions[2].answer)
+        assertEquals(sharedQuestions[1].tags[0].name, questions[1].tags[0].name)
+        assertEquals(sharedQuestions[1].tags[0].id, questions[1].tags[0].id)
     }
 }

--- a/src/test/kotlin/com/swm_standard/phote/entity/QuestionTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/QuestionTest.kt
@@ -2,10 +2,22 @@ package com.swm_standard.phote.entity
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.navercorp.fixturemonkey.FixtureMonkey
+import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
+import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
+import com.navercorp.fixturemonkey.kotlin.giveMeOne
+import com.navercorp.fixturemonkey.kotlin.size
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import kotlin.test.assertNotNull
 
 class QuestionTest {
+    private val fixtureMonkey: FixtureMonkey =
+        FixtureMonkey
+            .builder()
+            .plugin(KotlinPlugin())
+            .build()
+
     private fun createQuestion(): Question {
         val objectMapper = ObjectMapper()
         val jsonString = """
@@ -41,5 +53,22 @@ class QuestionTest {
         // then
         val expectedList = listOf("삼각형", "사각형", "마름모", "평행사변형", "원")
         assertEquals(expectedList, deserializedOptions)
+    }
+
+    @Test
+    fun `공유받은 문제를 복사해서 저장한다`() {
+        val questions = fixtureMonkey.giveMeBuilder<Question>().size(Question::tags, 0).sampleList(5)
+        val member: Member = fixtureMonkey.giveMeOne()
+
+        assertNotNull(questions[0])
+
+        println("fixtureMonkey = ${questions[0]}")
+
+        val sharedQuestions = Question.createSharedQuestions(questions, member)
+
+        assertEquals(sharedQuestions.size, questions.size)
+        assertEquals(sharedQuestions[0].member, member)
+        assertEquals(sharedQuestions[1].category, questions[1].category)
+        assertEquals(sharedQuestions[2].answer, questions[2].answer)
     }
 }

--- a/src/test/kotlin/com/swm_standard/phote/entity/WorkbookTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/WorkbookTest.kt
@@ -14,6 +14,7 @@ class WorkbookTest {
 
         Assertions.assertThat(workbook.title).isEqualTo(testTitle)
         Assertions.assertThat(workbook.emoji).isEqualTo("➗")
+        Assertions.assertThat(workbook.member.email).isEqualTo(member.email)
     }
 
     @Test


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- jacoco test coverage에 맞게 테스트 코드 작성했습니다.

---

### ✨ 참고 사항

- 자바 lombok 과 같은 경우에는 getter, setter를 제외시키는 설정을 따로 할 수 있는데 kotlin의 프로퍼티는 따로 제외할 수 있는 방법이 없어서 `method coverage` 퍼센티지를 낮춰놓는 쪽으로 진행했습니다.
- `method coverage` : 0.4 , `branch coverage` : 0.5
    - 개인적으로 `branch coverage`는 비율을 더 높여도 좋을 것 같습니다!
- 또 #203 에서 gradle의 test 태스크에 `jacocoTestReport 생성 프로세스`를 모두 합쳤었는데 이렇게 하니 테스트 코드 작성 시에 한 메서드 씩 실행하는 경우 `jacocoTestCoverageVerification` 을 위반하는 불편함이 있었습니다. (다른 테스트 코드는 실행을 안하니 커버리지 0 달성) 따라서 `./gradlew test` 커맨드 시에는 단순 테스트, `./gradlew jacocoTestReport` 시에는 테스트 후 jacocoTestReport 를 생성하도록 프로세스를 변경했습니다. 
> 사실 #201 이 PR 테스트해볼 때 전 결과가 계속 똑같이 나와서 이해를 잘못했었는데 알고보니 계속 `./gradlew test jacocoTestReport` 로 실행을 해서 그런거더라구요..?!! 허허

---

### ⏰ 현재 버그

x

---

### ✏ Git Close

- #206 
