### PR TITLE
Feat: GitActions 와 Jacoco 연동

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -8,7 +8,7 @@ on:
 permissions: write-all
 
 jobs:
-    build:
+    setting:
         runs-on: ubuntu-latest
 
         steps:
@@ -21,23 +21,40 @@ jobs:
 
             - name: Set up properties
               run: |
-                cd src/main
-                mkdir resources
-                cd resources
-                touch application.properties
-                echo "${{ secrets.APPLICATION }}" > application.properties
-                cat application.properties
+                  cd src/main
+                  mkdir resources
+                  cd resources
+                  touch application.properties
+                  echo "${{ secrets.APPLICATION }}" > application.properties
+                  cat application.properties
 
               shell: bash
 
             - name: Grant execute permission for gradlew
               run: chmod +x gradlew
 
-            - name: Test with Gradle
-              run: ./gradlew clean build jacocoTestReport
+    test:
+        runs-on: ubuntu-latest
+        needs: setting
 
-            - name: Publish Unit Test Results
-              uses: EnricoMi/publish-unit-test-result-action@v1
-              if: ${{ always() }}
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Set up JDK 17
+              uses: actions/setup-java@v3
               with:
-                  files: build/test-results/**/*.xml
+                  java-version: '17'
+                  distribution: 'temurin'
+
+            - name: Test with Gradle
+              run: ./gradlew clean jacocoTestReport
+
+            - name: Add coverage to PR
+              id: jacoco
+              uses: madrapps/jacoco-report@v1.2
+              with:
+                    paths: ${{ github.workspace }}/build/jacoco/index.xml
+                    token: ${{ secrets.GITHUB_TOKEN }}
+                    title: "테스트 커버리지 측정"
+                    min-coverage-overall: 40
+                    min-coverage-changed-files: 40

--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -33,18 +33,6 @@ jobs:
             - name: Grant execute permission for gradlew
               run: chmod +x gradlew
 
-    test:
-        runs-on: ubuntu-latest
-        needs: setting
-
-        steps:
-            - uses: actions/checkout@v3
-
-            - name: Set up JDK 17
-              uses: actions/setup-java@v3
-              with:
-                  java-version: '17'
-                  distribution: 'temurin'
 
             - name: Test with Gradle
               run: ./gradlew clean jacocoTestReport


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- jacoco 테스트 커버리지 결과를 PR 코멘트에 남기기 위해 `develop-ci.yml` 에 기능을 추가했습니다.
- ~~그리고 앞으로 actions 실패 시 실패한 job만 빠르게 재실행할 수 있게 jobs를 둘로 나누어두었습니다.~~ 하려고 했는데 jobs 간의 환경이 공유가 안된다고 하네요..

---

### ✨ 참고 사항

x

---

### ⏰ 현재 버그

x

---

### ✏ Git Close

- #212 
