### PR TITLE
HOTFIX: characterEncodingFilter 오류

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/common/tomcat/TomcatWebCustomConfig.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/tomcat/TomcatWebCustomConfig.kt
@@ -1,0 +1,20 @@
+package com.swm_standard.phote.common.tomcat
+
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory
+import org.springframework.boot.web.server.WebServerFactoryCustomizer
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class TomcatWebCustomConfig : WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+    override fun customize(factory: TomcatServletWebServerFactory) {
+        factory.addConnectorCustomizers(
+            TomcatConnectorCustomizer { connector ->
+                connector.setProperty(
+                    "relaxedQueryChars",
+                    "<>[\\]^`{|}",
+                )
+            },
+        )
+    }
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- newrelic 을 통해 지속적으로 characterEncodingFilter 관련 오류가 발생해 `TomcatWebCustomConfig` 클래스를 작성하여 **Tomcat** 을 커스텀했습니다. 
- 그런데 존재하는 api 중에서 쿼리 파라미터 등에 `[]` 같은 특수문자를 사용하는게 없을 뿐더러 지속적으로 오류가 나는걸보니 api 요청때문에 발생하는 오류가 아닌 것 같아서 찜찜합니다이...

---

### ✨ 참고 사항

- 명절이기도 하고.. 금방 고쳐야할 것 같아서 리뷰 패스할게용

---

### ⏰ 현재 버그

x

---

### ✏ Git Close

- #219 
