### PR TITLE
HOTFIX: newrelic healthcheck authentication 오류

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/common/authority/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/authority/JwtAuthenticationFilter.kt
@@ -17,7 +17,10 @@ class JwtAuthenticationFilter(
         chain: FilterChain?,
     ) {
         val accessToken = resolveToken(request as HttpServletRequest)
-        if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
+        if (accessToken != null &&
+            jwtTokenProvider.validateToken(accessToken) &&
+            request.getHeader("userAgent")?.contains("ELB-HealthChecker/2.0") == false
+        ) {
             val authentication = jwtTokenProvider.getAuthentication(accessToken)
             SecurityContextHolder.getContext().authentication = authentication
         }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- newrelic apm 에서 지속적으로 발생하는 access denied 오류가 apm에서 주기적으로 헬스체크를 하는데 이 과정 중 authentication 때문에 발생하는 오류 같아서 이를 수정했습니다. 

---

### ✨ 참고 사항

- 배포 후 확인해볼 수 있어서 일단 머지 하겠습니다..! ㅠㅠ

---

### ⏰ 현재 버그

---

### ✏ Git Close

- #219 
