### PR TITLE
HOTFIX: health check 용 api 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,4 @@ application.properties
 .gradle
 build
 resources
+/newrelic/newrelic.yml

--- a/src/main/kotlin/com/swm_standard/phote/common/authority/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/authority/JwtAuthenticationFilter.kt
@@ -17,9 +17,8 @@ class JwtAuthenticationFilter(
         chain: FilterChain?,
     ) {
         val accessToken = resolveToken(request as HttpServletRequest)
-        if (accessToken != null &&
-            jwtTokenProvider.validateToken(accessToken) &&
-            request.getHeader("userAgent")?.contains("ELB-HealthChecker/2.0") == false
+
+        if (accessToken != null && jwtTokenProvider.validateToken(accessToken)
         ) {
             val authentication = jwtTokenProvider.getAuthentication(accessToken)
             SecurityContextHolder.getContext().authentication = authentication

--- a/src/main/kotlin/com/swm_standard/phote/common/authority/SecurityConfig.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/authority/SecurityConfig.kt
@@ -23,7 +23,7 @@ class SecurityConfig(
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests {
                 it
-                    .requestMatchers("/api/auth/*")
+                    .requestMatchers("/api/auth/*", "/")
                     .anonymous()
                     .requestMatchers("/v3/**", "/swagger-ui/**", "api/token")
                     .permitAll()

--- a/src/main/kotlin/com/swm_standard/phote/controller/HealthCheckController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/HealthCheckController.kt
@@ -1,0 +1,11 @@
+package com.swm_standard.phote.controller
+
+import com.swm_standard.phote.common.responsebody.BaseResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class HealthCheckController {
+    @GetMapping("/")
+    fun healthCheck(): BaseResponse<String> = BaseResponse(data = "정상 작동 중")
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

<img width="700" alt="스크린샷 2024-09-21 오후 7 00 03" src="https://github.com/user-attachments/assets/aebb25bd-1346-4fd0-8413-c48a0aa616f3">

- 지속적으로 발생하는 `access denied`의 원인이 **apm 이 주기적으로  "/" 엔드포인트로 헬스 체크를 하기 때문**이었습니다..! 기존에는 `auth` 관련 엔드포인트를 제외한 모든 엔드포인트가 **authenticated** 확인이 필요했으므로 access  denied 가 발생하는 것이었습니다.
  -  따라서 해당 부분을 **anonymous** 로 설정했습니다.
- 더하여 "/" 엔드 포인트를 헬스 체크 엔드 포인트로 지정하여 response를 반환하도록 해서 `no static resource` 오류가 발생하는 것을 방지했습니다.
- 리뷰 없이 머지했던 부분에서 헤더 값으로 `ELB-HealthChecker/2.0` 이 있는지 체크하여, 존재하는 경우 token validation 을 패스하도록 했는데 위와 같이 **anonymous** 로 지정해주기만 하면돼서 해당 부분은 삭제했습니다.
- 테스트는 로컬에서 직접 도커 빌드해서 푸시하는 방법으로 완료했습니다..!


---

### ✨ 참고 사항

- 이제 error rate 100% 아니당..

---

### ⏰ 현재 버그

x

---

### ✏ Git Close

- #219 
