### PR TITLE
Feat: JPA 쿼리 성능 개선

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/WorkbookController.kt
@@ -3,15 +3,36 @@ package com.swm_standard.phote.controller
 import com.swm_standard.phote.common.exception.InvalidInputException
 import com.swm_standard.phote.common.resolver.memberId.MemberId
 import com.swm_standard.phote.common.responsebody.BaseResponse
-import com.swm_standard.phote.dto.*
+import com.swm_standard.phote.dto.AddQuestionsToWorkbookRequest
+import com.swm_standard.phote.dto.CreateWorkbookRequest
+import com.swm_standard.phote.dto.CreateWorkbookResponse
+import com.swm_standard.phote.dto.DeleteQuestionInWorkbookResponse
+import com.swm_standard.phote.dto.DeleteWorkbookResponse
+import com.swm_standard.phote.dto.ReadQuestionsInWorkbookResponse
+import com.swm_standard.phote.dto.ReadWorkbookDetailResponse
+import com.swm_standard.phote.dto.ReadWorkbookListResponse
+import com.swm_standard.phote.dto.ReceiveSharedWorkbookRequest
+import com.swm_standard.phote.dto.ReceiveSharedWorkbookResponse
+import com.swm_standard.phote.dto.UpdateQuestionSequenceRequest
+import com.swm_standard.phote.dto.UpdateQuestionSequenceResponse
+import com.swm_standard.phote.dto.UpdateWorkbookDetailRequest
+import com.swm_standard.phote.dto.UpdateWorkbookDetailResponse
 import com.swm_standard.phote.service.WorkbookService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.springframework.web.bind.annotation.*
-import java.util.*
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
 
 @RestController
 @RequestMapping("/api")

--- a/src/main/kotlin/com/swm_standard/phote/repository/CustomWorkbookRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/CustomWorkbookRepository.kt
@@ -1,0 +1,8 @@
+package com.swm_standard.phote.repository
+
+import com.swm_standard.phote.entity.Workbook
+import java.util.UUID
+
+interface CustomWorkbookRepository {
+    fun findWorkbooksByMember(memberId: UUID): List<Workbook>
+}

--- a/src/main/kotlin/com/swm_standard/phote/repository/CustomWorkbookRepositoryImpl.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/CustomWorkbookRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.swm_standard.phote.repository
+
+import com.swm_standard.phote.entity.Workbook
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import java.util.UUID
+
+class CustomWorkbookRepositoryImpl : CustomWorkbookRepository {
+    @PersistenceContext
+    private lateinit var em: EntityManager
+
+    override fun findWorkbooksByMember(memberId: UUID): List<Workbook> =
+        em
+            .createQuery(
+                "select w from Workbook w" +
+                    " join fetch w.member m" +
+                    " where m.id = :memberId",
+                Workbook::class.java,
+            ).setParameter("memberId", memberId)
+            .resultList
+}

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetCustomRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetCustomRepository.kt
@@ -1,8 +1,11 @@
 package com.swm_standard.phote.repository
 
+import com.swm_standard.phote.dto.ReadQuestionsInWorkbookResponse
 import com.swm_standard.phote.entity.Workbook
+import java.util.UUID
 
 interface QuestionSetCustomRepository {
-
     fun findMaxSequenceByWorkbookId(workbook: Workbook): Int
+
+    fun findAllQuestionsInWorkbook(workbookId: UUID): List<ReadQuestionsInWorkbookResponse>
 }

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetCustomRepositoryImpl.kt
@@ -1,19 +1,84 @@
 package com.swm_standard.phote.repository
 
 import com.querydsl.jpa.impl.JPAQueryFactory
+import com.swm_standard.phote.dto.ReadQuestionsInWorkbookResponse
 import com.swm_standard.phote.entity.QQuestionSet.questionSet
+import com.swm_standard.phote.entity.Question
+import com.swm_standard.phote.entity.QuestionSet
 import com.swm_standard.phote.entity.Workbook
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
 import org.springframework.stereotype.Repository
+import java.util.UUID
+import java.util.stream.Collectors
 
 @Repository
-class QuestionSetCustomRepositoryImpl(private val jpaQueryFactory: JPAQueryFactory) : QuestionSetCustomRepository {
+class QuestionSetCustomRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory,
+) : QuestionSetCustomRepository {
+    @PersistenceContext
+    private lateinit var em: EntityManager
+
     override fun findMaxSequenceByWorkbookId(workbook: Workbook): Int {
-        val maxSequence: Int? = jpaQueryFactory.select(questionSet.sequence.max())
-            .from(questionSet)
-            .where(questionSet.workbook.eq(workbook))
-            .fetchOne()
+        val maxSequence: Int? =
+            jpaQueryFactory
+                .select(questionSet.sequence.max())
+                .from(questionSet)
+                .where(questionSet.workbook.eq(workbook))
+                .fetchOne()
 
         if (maxSequence == null) return 0
         return maxSequence
+    }
+
+    override fun findAllQuestionsInWorkbook(workbookId: UUID): List<ReadQuestionsInWorkbookResponse> {
+        val questionSetIds = toQuestionSetIds(workbookId)
+
+        val questions =
+            em
+                .createQuery(
+                    "select q" +
+                        " from Question q" +
+                        " join q.questionSet qs" +
+                        " join fetch q.tags t" +
+                        " where qs.id in :questionSetIds" +
+                        " order by qs.sequence",
+                    Question::class.java,
+                ).setParameter("questionSetIds", questionSetIds)
+                .resultList
+
+        var index = 0
+
+        val responses =
+            questions.map { q ->
+                ReadQuestionsInWorkbookResponse(
+                    questionId = q.id,
+                    questionSetId = questionSetIds[index++],
+                    statement = q.statement,
+                    category = q.category,
+                    image = q.image,
+                    tags = q.tags,
+                    options = q.deserializeOptions(),
+                )
+            }
+
+        return responses
+    }
+
+    private fun toQuestionSetIds(workbookId: UUID): List<UUID> {
+        val questionSets: MutableList<QuestionSet> =
+            em
+                .createQuery(
+                    "select qs from QuestionSet qs" +
+                        " where qs.workbook.id = :workbookId" +
+                        " order by qs.sequence",
+                    QuestionSet::class.java,
+                ).setParameter("workbookId", workbookId)
+                .resultList
+
+        return questionSets
+            .stream()
+            .map { o -> o.id }
+            .collect(Collectors.toList())
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/QuestionSetRepository.kt
@@ -16,6 +16,4 @@ interface QuestionSetRepository :
         questionId: UUID,
         workbookId: UUID,
     ): Boolean
-
-    fun findByWorkbookIdOrderBySequence(workbookId: UUID): List<QuestionSet>
 }

--- a/src/main/kotlin/com/swm_standard/phote/repository/TagRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/TagRepository.kt
@@ -2,8 +2,5 @@ package com.swm_standard.phote.repository
 
 import com.swm_standard.phote.entity.Tag
 import org.springframework.data.jpa.repository.JpaRepository
-import java.util.UUID
 
-interface TagRepository : JpaRepository<Tag, Long> {
-    fun findAllByQuestionId(questionId: UUID): List<Tag>?
-}
+interface TagRepository : JpaRepository<Tag, Long>

--- a/src/main/kotlin/com/swm_standard/phote/repository/WorkbookRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/WorkbookRepository.kt
@@ -1,11 +1,9 @@
 package com.swm_standard.phote.repository
 
-import com.swm_standard.phote.entity.Member
 import com.swm_standard.phote.entity.Workbook
 import org.springframework.data.jpa.repository.JpaRepository
-import java.util.*
+import java.util.UUID
 
-interface WorkbookRepository : JpaRepository<Workbook, UUID> {
-
-    fun findAllByMember(member: Member): List<Workbook>
-}
+interface WorkbookRepository :
+    JpaRepository<Workbook, UUID>,
+    CustomWorkbookRepository

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -53,18 +53,22 @@ class ExamService(
         val responses =
             buildList {
                 exam.answers.forEach { answer ->
-                    add(
-                        ReadExamHistoryDetail(
-                            statement = answer.question.statement,
-                            options = answer.question.options?.let { answer.question.deserializeOptions() },
-                            image = answer.question.image,
-                            category = answer.question.category,
-                            answer = answer.question.answer,
-                            submittedAnswer = answer.submittedAnswer,
-                            isCorrect = answer.isCorrect,
-                            sequence = answer.sequence,
-                        ),
-                    )
+                    val question = answer.question
+                    if (question != null) {
+                        println("question")
+                        add(
+                            ReadExamHistoryDetail(
+                                statement = question.statement,
+                                options = question.options?.let { question.deserializeOptions() },
+                                image = question.image,
+                                category = question.category,
+                                answer = question.answer,
+                                submittedAnswer = answer.submittedAnswer,
+                                isCorrect = answer.isCorrect,
+                                sequence = answer.sequence,
+                            ),
+                        )
+                    }
                 }
             }
 

--- a/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/WorkbookService.kt
@@ -74,8 +74,7 @@ class WorkbookService(
     }
 
     fun readWorkbookList(memberId: UUID): List<ReadWorkbookListResponse> {
-        val member = getMember(memberId)
-        val workbooks: List<Workbook> = workbookRepository.findAllByMember(member)
+        val workbooks: List<Workbook> = workbookRepository.findWorkbooksByMember(memberId)
 
         return workbooks.map { workbook ->
             ReadWorkbookListResponse(
@@ -169,19 +168,10 @@ class WorkbookService(
     fun readQuestionsInWorkbook(workbookId: UUID): List<ReadQuestionsInWorkbookResponse> {
         getWorkbook(workbookId)
 
-        val questionSets: List<QuestionSet> = questionSetRepository.findByWorkbookIdOrderBySequence(workbookId)
+        val questionSets: List<ReadQuestionsInWorkbookResponse> =
+            questionSetRepository.findAllQuestionsInWorkbook(workbookId)
 
-        return questionSets.map { set ->
-            ReadQuestionsInWorkbookResponse(
-                set.id,
-                set.question.id,
-                set.question.statement,
-                set.question.options?.let { set.question.deserializeOptions() },
-                set.question.image,
-                set.question.category,
-                set.question.tags,
-            )
-        }
+        return questionSets
     }
 
     @Transactional

--- a/src/test/kotlin/com/swm_standard/phote/entity/QuestionTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/QuestionTest.kt
@@ -26,14 +26,15 @@ class QuestionTest {
         // given
         val optionList =
             listOf(
-                Arbitraries.strings().sample(),
-                Arbitraries.strings().sample(),
-                Arbitraries.strings().sample(),
-                Arbitraries.strings().sample(),
-                Arbitraries.strings().sample(),
+                Arbitraries.strings().withoutEdgeCases().sample(),
+                Arbitraries.strings().withoutEdgeCases().sample(),
+                Arbitraries.strings().withoutEdgeCases().sample(),
+                Arbitraries.strings().withoutEdgeCases().sample(),
+                Arbitraries.strings().withoutEdgeCases().sample(),
             )
 
-        val json = """
+        val json =
+            """
         {
             "1": "${optionList[0]}",
             "2": "${optionList[1]}",

--- a/src/test/kotlin/com/swm_standard/phote/entity/WorkbookTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/WorkbookTest.kt
@@ -26,7 +26,6 @@ class WorkbookTest {
         val member: Member = fixtureMonkey.giveMeOne()
         val testTitle = Arbitraries.strings().sample() + "math"
 
-        println(testTitle)
         val workbook: Workbook = Workbook.createWorkbook(title = testTitle, description = "", member = member)
 
         assertThat(workbook.title).isEqualTo(testTitle)


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 주요 커밋은 53aca8b51049bb101384b64fbd1d1ddd14b595b4 입니다!
- `readQuestionsInWorkbook` 기능에서 **특정 workbook 에 존재하는 questionSetId 리스트 조회 -> questionSetId를 가지는 Question 리스트 조회 -> 각 Question 마다 태그 엔티티 조회** 를 거쳐야해서 N+1 문제가 존재했습니다. 
- 따라서 workbook 에 존재하는 questionSetId 리스트를 얻은 후에는 **questionSet과 Question을 `fetch join`** 하고 **Question과 Tag는 프로퍼티로 설정한 `batch size` 로 성능 개선**을 할 수 있도록 했습니다.

---

### ✨ 참고 사항

- 두 관계 (Question 과 Tag, Question 과 QuestionSet) 모두  fetch join으로 설정해버리면 아래와 같은 multiple bags 오류가 발생합니다. 
```
org.hibernate.loader.MultipleBagFetchException: cannot simultaneously fetch multiple bags
```

- 따라서 둘 중 어떤 걸 fetch로 join 해야할 지 선택해야 했는데  dto에 tag 엔티티의 필드도 담아야했기 때문에 (== 즉시로딩을 해야하기 때문에) tag를 fetch join 하는 것으로 결정했습니다.
  - 실제로 이 반대로 fetch join 을 세팅할 경우 tag 엔티티 조회를 위해 쿼리가 한번 더 나가는 것을 확인할 수 있습니다.

- ✅✅ 일전에 말했던 `deserializeOptions()` 는 유틸 메서드로 사용하는 대신 원래대로 사용하도록 복원해뒀습니다.  dto로 바로 조회하는 대신 question 엔티티 조회로 진행했습니다.

---

### ⏰ 현재 버그

- `deserializeOptions()` 테스트에서 옵션에 `"` 와 같은 escape 문자가 필요한 것들이 들어오면 오류가 발생했습니다. 일단 edge case 없이 예시 옵션을 생성하도록 했습니다. 

x

---

### ✏ Git Close

- #217 
