### PR TITLE
Fix: readQuestionsInWorkbook 문제 안읽히는 버그 수정

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/repository/questionsetrepository/QuestionSetCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/questionsetrepository/QuestionSetCustomRepositoryImpl.kt
@@ -60,7 +60,7 @@ class QuestionSetCustomRepositoryImpl(
         val questionSets: MutableList<QuestionSet> =
             jpaQueryFactory
                 .selectFrom(questionSet)
-                .where(questionSet.id.eq(workbookId))
+                .where(questionSet.workbook.id.eq(workbookId))
                 .orderBy(questionSet.sequence.asc())
                 .fetch()
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- queryDSL 로직 오류로 문제집 내 문제가 안읽혀서 수정했슴다

---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close #235 
