### PR TITLE
Fix: cd 빌드 시 ktLintCheck 태스크 삭제

### DIFF
--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -46,7 +46,7 @@ jobs:
               run: chmod +x gradlew
 
             - name: Build with Gradle
-              run: ./gradlew build -x test
+              run: ./gradlew build -x test -x ktlintCheck
 
             - name: Docker build
               run: |


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 로컬에서도 한번씩 이상이 없어도 `ktLintCheck` 에서 걸리는 경우가 있는데 서비스 작동과는 무관하므로 빌드 시에는 체크 태스크를 제외하도록 했습니다!!

---

### ✨ 참고 사항

x

---

### ⏰ 현재 버그

x

---

### ✏ Git Close

- #241 
