### PR TITLE
Feat: gradeExam 공유용 시험도 함께 사용할 수 있도록 구현

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
@@ -2,11 +2,11 @@ package com.swm_standard.phote.controller
 
 import com.swm_standard.phote.common.responsebody.BaseResponse
 import com.swm_standard.phote.dto.LoginRequest
+import com.swm_standard.phote.dto.MemberInfoResponse
 import com.swm_standard.phote.dto.RenewAccessTokenResponse
-import com.swm_standard.phote.dto.UserInfoResponse
+import com.swm_standard.phote.service.AppleAuthService
 import com.swm_standard.phote.service.GoogleAuthService
 import com.swm_standard.phote.service.KaKaoAuthService
-import com.swm_standard.phote.service.AppleAuthService
 import com.swm_standard.phote.service.TokenService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -30,36 +30,36 @@ class AuthController(
     @PostMapping("/google-login")
     fun googleLogin(
         @RequestBody request: LoginRequest,
-    ): BaseResponse<UserInfoResponse> {
+    ): BaseResponse<MemberInfoResponse> {
         val accessToken = googleAuthService.getTokenFromGoogle(request)
-        val userInfo = googleAuthService.getUserInfoFromGoogle(accessToken)
+        val memberInfo = googleAuthService.getMemberInfoFromGoogle(accessToken)
 
-        val message = if (userInfo.isMember == false) "회원가입 성공" else "로그인 성공"
-        return BaseResponse(msg = message, data = userInfo)
+        val message = if (memberInfo.isMember == false) "회원가입 성공" else "로그인 성공"
+        return BaseResponse(msg = message, data = memberInfo)
     }
 
     @Operation(summary = "kakao-login", description = "카카오 로그인/회원가입")
     @PostMapping("/kakao-login")
     fun kakaoLogin(
         @RequestBody request: LoginRequest,
-    ): BaseResponse<UserInfoResponse> {
+    ): BaseResponse<MemberInfoResponse> {
         val accessToken = kaKaoAuthService.getTokenFromKakao(request)
-        val userInfo = kaKaoAuthService.getUserInfoFromKakao(accessToken)
+        val memberInfo = kaKaoAuthService.getMemberInfoFromKakao(accessToken)
 
-        val message = if (userInfo.isMember == false) "회원가입 성공" else "로그인 성공"
-        return BaseResponse(msg = message, data = userInfo)
+        val message = if (memberInfo.isMember == false) "회원가입 성공" else "로그인 성공"
+        return BaseResponse(msg = message, data = memberInfo)
     }
 
     @Operation(summary = "apple-login", description = "애플 로그인/회원가입")
     @PostMapping("/apple-login")
     fun appleLogin(
         @RequestBody request: LoginRequest,
-    ): BaseResponse<UserInfoResponse> {
+    ): BaseResponse<MemberInfoResponse> {
         val idToken = appleAuthService.getTokenFromApple(request)
-        val userInfo = appleAuthService.getUserInfoFromApple(idToken)
+        val memberInfo = appleAuthService.getMemberInfoFromApple(idToken)
 
-        val message = if (userInfo.isMember == false) "회원가입 성공" else "로그인 성공"
-        return BaseResponse(msg = message, data = userInfo)
+        val message = if (memberInfo.isMember == false) "회원가입 성공" else "로그인 성공"
+        return BaseResponse(msg = message, data = memberInfo)
     }
 
     @Operation(summary = "renewAccessToken", description = "refreshToken으로 accessToken 갱신")

--- a/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
@@ -61,13 +61,12 @@ class ExamController(
 
     @Operation(summary = "gradeExam", description = "문제풀이 제출 및 채점")
     @SecurityRequirement(name = "bearer Auth")
-    @PostMapping("/exam/{workbookId}")
+    @PostMapping("/exam")
     fun gradeExam(
-        @PathVariable(required = true) workbookId: UUID,
         @Valid @RequestBody request: GradeExamRequest,
         @Parameter(hidden = true) @MemberId memberId: UUID,
     ): BaseResponse<GradeExamResponse> {
-        val response = examService.gradeExam(workbookId, request, memberId)
+        val response = examService.gradeExam(request, memberId)
 
         return BaseResponse(msg = "문제 풀이 채점 성공", data = response)
     }
@@ -76,7 +75,7 @@ class ExamController(
     @SecurityRequirement(name = "bearer Auth")
     @PostMapping("/exam/create")
     fun createSharedExam(
-        @MemberId memberId: UUID,
+        @Parameter(hidden = true) @MemberId memberId: UUID,
         @Valid @RequestBody request: CreateSharedExamRequest,
     ): BaseResponse<CreateSharedExamResponse> {
         val sharedExamId: UUID = examService.createSharedExam(memberId, request)

--- a/src/main/kotlin/com/swm_standard/phote/dto/AuthDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/AuthDtos.kt
@@ -16,13 +16,13 @@ data class GoogleAccessResponse(
     val idToken: String,
 )
 
-data class UserInfoResponse(
+data class MemberInfoResponse(
     var accessToken: String? = null,
     var name: String?,
     val email: String,
     var picture: String,
     var isMember: Boolean? = true,
-    var userId: UUID?,
+    var memberId: UUID?,
 ) {
     var refreshToken: UUID? = null
 }

--- a/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
@@ -49,6 +49,8 @@ data class ReadExamResultsResponse(
 
 data class GradeExamRequest(
     val time: Int,
+    val workbookId: UUID?,
+    val examId: UUID?,
     val answers: List<SubmittedAnswerRequest>,
 )
 

--- a/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
@@ -35,7 +35,7 @@ data class ReadExamHistoryListResponse(
 )
 
 data class ReadExamStudentResult(
-    val userId: UUID,
+    val memberId: UUID,
     val name: String,
     val score: Int,
     val time: Int,

--- a/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
@@ -2,6 +2,7 @@ package com.swm_standard.phote.entity
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -16,7 +17,7 @@ import java.util.UUID
 @Inheritance(strategy = InheritanceType.JOINED)
 @SQLDelete(sql = "UPDATE exam SET deleted_at = NOW() WHERE exam_id = ?")
 data class Exam(
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     val member: Member,
     @ManyToOne

--- a/src/main/kotlin/com/swm_standard/phote/entity/ExamResult.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/ExamResult.kt
@@ -9,8 +9,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
-import org.hibernate.annotations.OnDelete
-import org.hibernate.annotations.OnDeleteAction
 import org.hibernate.annotations.SQLDelete
 import java.util.UUID
 
@@ -23,7 +21,6 @@ data class ExamResult(
     val time: Int,
     @JoinColumn(name = "exam_id")
     @ManyToOne
-    @OnDelete(action = OnDeleteAction.CASCADE)
     val exam: Exam,
 ) : BaseTimeEntity() {
     @Id

--- a/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Question.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.Lob
@@ -24,7 +25,7 @@ import java.util.UUID
 data class Question(
     @Id @Column(name = "question_uuid", nullable = false, unique = true)
     val id: UUID = UUID.randomUUID(),
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     @JsonIgnore
     val member: Member,

--- a/src/main/kotlin/com/swm_standard/phote/entity/SharedExam.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/SharedExam.kt
@@ -9,6 +9,7 @@ class SharedExam(
     val startTime: LocalDateTime,
     val endTime: LocalDateTime,
     var capacity: Int,
+    var examineeCount: Int = 0,
     member: Member,
     workbook: Workbook,
     sequence: Int = 1,
@@ -50,5 +51,22 @@ class SharedExam(
                 throw BadRequestException(fieldName = "capacity", message = "시험 수용 인원은 1명~20명입니다.")
             }
         }
+    }
+
+    fun validateSubmissionTime() {
+        if (startTime.isAfter(LocalDateTime.now()) || endTime.isBefore(LocalDateTime.now())) {
+            throw BadRequestException(fieldName = "submissionTime", message = "제출 시간이 시작 시간 전이거나 종료 시간 이후입니다.")
+        }
+    }
+
+    fun validateCapacity() {
+        if (capacity <= examineeCount) {
+            throw BadRequestException(fieldName = "capacity", message = "시험 수용인원을 초과했습니다.")
+        }
+    }
+
+    fun increaseExamineeCount() {
+        validateCapacity()
+        examineeCount += 1
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/repository/questionrepository/QuestionCustomRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/questionrepository/QuestionCustomRepository.kt
@@ -2,7 +2,7 @@ package com.swm_standard.phote.repository.questionrepository
 
 import com.swm_standard.phote.dto.SearchQuestionsToAddResponse
 import com.swm_standard.phote.entity.Question
-import java.util.*
+import java.util.UUID
 
 interface QuestionCustomRepository {
     fun searchQuestionsList(

--- a/src/main/kotlin/com/swm_standard/phote/repository/questionrepository/QuestionRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/questionrepository/QuestionRepository.kt
@@ -3,9 +3,11 @@ package com.swm_standard.phote.repository.questionrepository
 import com.swm_standard.phote.entity.Question
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import java.util.*
+import java.util.UUID
 
 @Repository
 interface QuestionRepository :
     JpaRepository<Question, UUID>,
-    QuestionCustomRepository
+    QuestionCustomRepository {
+    fun findAllByIdIn(questionIds: List<UUID>): List<Question>
+}

--- a/src/main/kotlin/com/swm_standard/phote/service/AppleAuthService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/AppleAuthService.kt
@@ -7,7 +7,7 @@ import com.swm_standard.phote.common.authority.JwtTokenProvider
 import com.swm_standard.phote.common.module.NicknameGenerator
 import com.swm_standard.phote.common.module.ProfileImageGenerator
 import com.swm_standard.phote.dto.LoginRequest
-import com.swm_standard.phote.dto.UserInfoResponse
+import com.swm_standard.phote.dto.MemberInfoResponse
 import com.swm_standard.phote.entity.Member
 import com.swm_standard.phote.entity.Provider
 import com.swm_standard.phote.repository.MemberRepository
@@ -29,8 +29,8 @@ import java.security.PrivateKey
 import java.security.Security
 import java.time.LocalDateTime
 import java.time.ZoneId
-import java.util.Date
 import java.util.Base64
+import java.util.Date
 
 @Service
 class AppleAuthService(
@@ -80,8 +80,7 @@ class AppleAuthService(
         return jsonNode["id_token"].asText()
     }
 
-    fun getUserInfoFromApple(token: String): UserInfoResponse {
-
+    fun getMemberInfoFromApple(token: String): MemberInfoResponse {
         val signedJWT: SignedJWT = SignedJWT.parse(token)
         val getPayload: JWTClaimsSet = signedJWT.getJWTClaimsSet()
 
@@ -110,12 +109,12 @@ class AppleAuthService(
         }
 
         val dto =
-            UserInfoResponse(
+            MemberInfoResponse(
                 name = member.name,
                 email = member.email,
                 picture = member.image,
                 isMember = isMember,
-                userId = member.id,
+                memberId = member.id,
                 accessToken = jwtTokenProvider.createToken(member.id),
             )
 
@@ -127,7 +126,8 @@ class AppleAuthService(
     private fun generateClientSecret(): String {
         val expiration: LocalDateTime = LocalDateTime.now().plusMinutes(5)
 
-        return Jwts.builder()
+        return Jwts
+            .builder()
             .setHeaderParam(JwsHeader.KEY_ID, keyId)
             .setIssuer(teamId)
             .setAudience(authUrl)

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -1,5 +1,6 @@
 package com.swm_standard.phote.service
 
+import com.swm_standard.phote.common.exception.BadRequestException
 import com.swm_standard.phote.common.exception.NotFoundException
 import com.swm_standard.phote.dto.AnswerResponse
 import com.swm_standard.phote.dto.ChatGPTRequest
@@ -10,15 +11,14 @@ import com.swm_standard.phote.dto.GradeExamResponse
 import com.swm_standard.phote.dto.ReadExamHistoryDetail
 import com.swm_standard.phote.dto.ReadExamHistoryDetailResponse
 import com.swm_standard.phote.dto.ReadExamHistoryListResponse
-import com.swm_standard.phote.dto.ReadExamStudentResult
 import com.swm_standard.phote.dto.ReadExamResultsResponse
+import com.swm_standard.phote.dto.ReadExamStudentResult
 import com.swm_standard.phote.dto.SubmittedAnswerRequest
 import com.swm_standard.phote.entity.Answer
 import com.swm_standard.phote.entity.Category
 import com.swm_standard.phote.entity.Exam
 import com.swm_standard.phote.entity.ExamResult
 import com.swm_standard.phote.entity.Member
-import com.swm_standard.phote.entity.Question
 import com.swm_standard.phote.entity.SharedExam
 import com.swm_standard.phote.entity.Workbook
 import com.swm_standard.phote.repository.AnswerRepository
@@ -110,69 +110,70 @@ class ExamService(
         val exam = examRepository.findById(examId).orElseThrow { NotFoundException(fieldName = "examId") }
         val examResults = examResultRepository.findAllByExamId(examId)
 
-        val responses = examResults.map { examResult ->
-            ReadExamStudentResult(
-                examResult.member.id,
-                examResult.member.name,
-                examResult.totalCorrect,
-                examResult.time,
-            )
-        }
+        val responses =
+            examResults.map { examResult ->
+                ReadExamStudentResult(
+                    examResult.member.id,
+                    examResult.member.name,
+                    examResult.totalCorrect,
+                    examResult.time,
+                )
+            }
 
         return ReadExamResultsResponse(examId, exam.workbook.quantity, responses)
     }
 
     @Transactional
     fun gradeExam(
-        workbookId: UUID,
         request: GradeExamRequest,
         memberId: UUID,
     ): GradeExamResponse {
-        val workbook =
-            workbookRepository
-                .findById(
-                    workbookId,
-                ).getOrElse { throw NotFoundException(fieldName = "workbook") }
+        val member = findMember(memberId)
 
         val exam =
-            examRepository.save(
-                Exam
-                    .createExam(
-                        memberRepository
-                            .findById(
-                                memberId,
-                            ).getOrElse { throw NotFoundException(fieldName = "member") },
-                        workbook,
-                        examRepository.findMaxSequenceByWorkbookId(workbook) + 1,
-                    ),
-            )
+            if (request.workbookId != null) {
+                val workbook = findWorkbook(request.workbookId)
+                isWorkbookOwner(workbook, memberId)
+
+                examRepository.save(
+                    Exam
+                        .createExam(
+                            member,
+                            workbook,
+                            examRepository.findMaxSequenceByWorkbookId(workbook) + 1,
+                        ),
+                )
+            } else {
+                examRepository
+                    .findById(
+                        checkNotNull(request.examId),
+                    ).orElseThrow { NotFoundException(fieldName = "exam") }
+            }
 
         val examResult =
             examResultRepository.save(
                 ExamResult.createExamResult(
-                    member =
-                    memberRepository
-                        .findById(
-                            memberId,
-                        ).orElseThrow { NotFoundException(fieldName = "member") },
+                    member = member,
                     time = request.time,
-                    exam,
+                    exam = exam,
                 ),
             )
 
         var totalCorrect = 0
 
+        val questions =
+            questionRepository
+                .findAllByIdIn(request.answers.map { answer -> answer.questionId })
+                .associateBy { it.id }
+
         val response =
             request.answers.mapIndexed { index: Int, answer: SubmittedAnswerRequest ->
-                val question: Question =
-                    questionRepository.findById(answer.questionId).getOrElse {
-                        throw NotFoundException(fieldName = "questionId (${answer.questionId})")
-                    }
+                val question = questions.getValue(answer.questionId)
 
                 val savingAnswer: Answer =
                     Answer.createAnswer(
                         question = question,
-                        submittedAnswer = answer.submittedAnswer,
+                        submittedAnswer = request.answers[index].submittedAnswer,
                         examResult = examResult,
                         sequence = index + 1,
                     )
@@ -212,6 +213,15 @@ class ExamService(
         )
     }
 
+    private fun isWorkbookOwner(
+        workbook: Workbook,
+        memberId: UUID,
+    ) {
+        if (workbook.member.id != memberId) {
+            throw BadRequestException(fieldName = "member", "사용자가 소유한 시험이 아닙니다.")
+        }
+    }
+
     @Transactional
     fun createSharedExam(
         memberId: UUID,
@@ -232,7 +242,10 @@ class ExamService(
     }
 
     private fun findWorkbook(workbookId: UUID): Workbook =
-        workbookRepository.findById(workbookId).orElseThrow { NotFoundException(fieldName = "workbook") }
+        workbookRepository
+            .findById(
+                workbookId,
+            ).getOrElse { throw NotFoundException(fieldName = "workbook") }
 
     private fun findMember(memberId: UUID): Member =
         memberRepository.findById(memberId).orElseThrow {

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -144,10 +144,16 @@ class ExamService(
                         ),
                 )
             } else {
-                examRepository
-                    .findById(
-                        checkNotNull(request.examId),
-                    ).orElseThrow { NotFoundException(fieldName = "exam") }
+                (
+                    examRepository
+                        .findById(
+                            checkNotNull(request.examId),
+                        ).orElseThrow { NotFoundException(fieldName = "exam") }
+                        as SharedExam
+                    ).apply {
+                    validateSubmissionTime()
+                    increaseExamineeCount()
+                }
             }
 
         val examResult =

--- a/src/main/kotlin/com/swm_standard/phote/service/GoogleAuthService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/GoogleAuthService.kt
@@ -5,7 +5,7 @@ import com.swm_standard.phote.common.module.NicknameGenerator
 import com.swm_standard.phote.common.module.ProfileImageGenerator
 import com.swm_standard.phote.dto.GoogleAccessResponse
 import com.swm_standard.phote.dto.LoginRequest
-import com.swm_standard.phote.dto.UserInfoResponse
+import com.swm_standard.phote.dto.MemberInfoResponse
 import com.swm_standard.phote.entity.Member
 import com.swm_standard.phote.entity.Provider
 import com.swm_standard.phote.repository.MemberRepository
@@ -52,7 +52,7 @@ class GoogleAuthService(
         return response.accessToken
     }
 
-    fun getUserInfoFromGoogle(token: String): UserInfoResponse {
+    fun getMemberInfoFromGoogle(token: String): MemberInfoResponse {
         val restTemplate = RestTemplate()
         val headers = HttpHeaders()
         val params: MutableMap<String, Any> = HashMap()
@@ -60,13 +60,13 @@ class GoogleAuthService(
 
         val googleTokenRequest: HttpEntity<MutableMap<String, Any>> = HttpEntity(params, headers)
 
-        val dto: UserInfoResponse =
+        val dto: MemberInfoResponse =
             restTemplate
                 .exchange(
                     "https://www.googleapis.com/userinfo/v2/me",
                     HttpMethod.GET,
                     googleTokenRequest,
-                    UserInfoResponse::class.java,
+                    MemberInfoResponse::class.java,
                 ).body!!
 
         var member = memberRepository.findByEmail(dto.email)
@@ -81,7 +81,7 @@ class GoogleAuthService(
 
         dto.accessToken = jwtTokenProvider.createToken(member.id)
         dto.refreshToken = tokenService.generateRefreshToken(member.id)
-        dto.userId = member.id
+        dto.memberId = member.id
         dto.name = member.name
 
         return dto

--- a/src/main/kotlin/com/swm_standard/phote/service/KaKaoAuthService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/KaKaoAuthService.kt
@@ -5,7 +5,7 @@ import com.swm_standard.phote.common.authority.JwtTokenProvider
 import com.swm_standard.phote.common.module.NicknameGenerator
 import com.swm_standard.phote.common.module.ProfileImageGenerator
 import com.swm_standard.phote.dto.LoginRequest
-import com.swm_standard.phote.dto.UserInfoResponse
+import com.swm_standard.phote.dto.MemberInfoResponse
 import com.swm_standard.phote.entity.Member
 import com.swm_standard.phote.entity.Provider
 import com.swm_standard.phote.repository.MemberRepository
@@ -53,7 +53,7 @@ class KaKaoAuthService(
         return jsonNode["access_token"].asText()
     }
 
-    fun getUserInfoFromKakao(token: String): UserInfoResponse {
+    fun getMemberInfoFromKakao(token: String): MemberInfoResponse {
         val headers = HttpHeaders()
         headers.add("Authorization", "Bearer $token")
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8")
@@ -96,12 +96,12 @@ class KaKaoAuthService(
         }
 
         val dto =
-            UserInfoResponse(
+            MemberInfoResponse(
                 name = member.name,
                 email = member.email,
                 picture = member.image,
                 isMember = isMember,
-                userId = member.id,
+                memberId = member.id,
                 accessToken = jwtTokenProvider.createToken(member.id),
             )
 

--- a/src/test/kotlin/com/swm_standard/phote/entity/ExamTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/ExamTest.kt
@@ -117,8 +117,8 @@ class ExamTest {
         val sharedExam =
             fixtureMonkey
                 .giveMeBuilder(SharedExam::class.java)
-                .setExp(SharedExam::startTime, LocalDateTime.now().plusDays(1))
                 .setExp(SharedExam::examineeCount, examineeCount)
+                .setExp(SharedExam::capacity, Arbitraries.integers().greaterOrEqual(examineeCount + 1))
                 .build()
                 .sample()
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 1aeda3249efa301e595c5c84e54c6e0c862d1210 커밋만 기능 구현관련 커밋입니다!
- 기존 gradeExam 에서 공유용 문제 풀이도 함께 사용할 수 있도록 했습니다.
  - 내 문제 풀이 채점 시에는 `workbookId` 를 명시하고 `examId` 를 **null** 
    - 내 문제 풀이 채점 시에는 **workbook 소유자**인지 확인하도록 했습니다.
  - 공유용 문제 풀이 채점 시에는 `examId` 를 명시하고 `workbookId` 를 **null**
- 이에 따라 엔드 포인트를 **[POST]** `/api/grade/{workbookId}` 에서 **[POST]**`/api/grade` 로 변경했습니다. 
- `user` 를 모두 `member`로 대체했습니다

---

### ✨ 참고 사항

- 기존 gradeExam 구현에서는 요청으로 들어오는 answer 들을 하나씩 거쳐가면서 question을 answer 개수만큼 조회했어야했는데 비효율적이라고 생각해서 필요한 question을 미리 모두 조회하는 것으로 변경했습니다. 
  - 이때 제출한 답안과 같은 순서대로 question이 조회됐어야했는데 이를 적용하려고 하니 nativequery, querydsl 모두 오류가 났습니다. 따라서 일단 순서 관계없이 조회 후 questionId 를 키 값으로 매핑하여 각 answer가 키 값으로 값을 가져오도록 했습니다. 

---

### ⏰ 현재 버그

x

---

### ✏ Git Close

- #230 
