### PR TITLE
Feat: 임시 자체 로그인 구현

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/AuthController.kt
@@ -3,10 +3,12 @@ package com.swm_standard.phote.controller
 import com.swm_standard.phote.common.responsebody.BaseResponse
 import com.swm_standard.phote.dto.LoginRequest
 import com.swm_standard.phote.dto.MemberInfoResponse
+import com.swm_standard.phote.dto.NativeLoginRequest
 import com.swm_standard.phote.dto.RenewAccessTokenResponse
 import com.swm_standard.phote.service.AppleAuthService
 import com.swm_standard.phote.service.GoogleAuthService
 import com.swm_standard.phote.service.KaKaoAuthService
+import com.swm_standard.phote.service.NativeAuthService
 import com.swm_standard.phote.service.TokenService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -25,6 +27,7 @@ class AuthController(
     private val kaKaoAuthService: KaKaoAuthService,
     private val appleAuthService: AppleAuthService,
     private val tokenService: TokenService,
+    private val nativeAuthService: NativeAuthService,
 ) {
     @Operation(summary = "google-login", description = "구글 로그인/회원가입")
     @PostMapping("/google-login")
@@ -57,6 +60,17 @@ class AuthController(
     ): BaseResponse<MemberInfoResponse> {
         val idToken = appleAuthService.getTokenFromApple(request)
         val memberInfo = appleAuthService.getMemberInfoFromApple(idToken)
+
+        val message = if (memberInfo.isMember == false) "회원가입 성공" else "로그인 성공"
+        return BaseResponse(msg = message, data = memberInfo)
+    }
+
+    @Operation(summary = "native-login", description = "자체 로그인")
+    @PostMapping("/native-login")
+    fun nativeLogin(
+        @RequestBody request: NativeLoginRequest,
+    ): BaseResponse<MemberInfoResponse> {
+        val memberInfo = nativeAuthService.getMemberInfoFromNative(request)
 
         val message = if (memberInfo.isMember == false) "회원가입 성공" else "로그인 성공"
         return BaseResponse(msg = message, data = memberInfo)

--- a/src/main/kotlin/com/swm_standard/phote/dto/AuthDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/AuthDtos.kt
@@ -35,3 +35,8 @@ data class LoginRequest(
     val code: String,
     val redirectUri: String,
 )
+
+data class NativeLoginRequest(
+    val email: String,
+    val password: String,
+)

--- a/src/main/kotlin/com/swm_standard/phote/service/NativeAuthService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/NativeAuthService.kt
@@ -1,0 +1,48 @@
+package com.swm_standard.phote.service
+
+import com.swm_standard.phote.common.authority.JwtTokenProvider
+import com.swm_standard.phote.common.exception.BadRequestException
+import com.swm_standard.phote.common.exception.NotFoundException
+import com.swm_standard.phote.dto.MemberInfoResponse
+import com.swm_standard.phote.dto.NativeLoginRequest
+import com.swm_standard.phote.repository.MemberRepository
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+
+@Service
+class NativeAuthService(
+    private val memberRepository: MemberRepository,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val tokenService: TokenService,
+    @Value("\${native-login.password}")
+    private val password: String,
+) {
+    fun getMemberInfoFromNative(request: NativeLoginRequest): MemberInfoResponse {
+        validatePassword(request)
+
+        var member = memberRepository.findByEmail(request.email) ?: throw NotFoundException(fieldName = "member")
+
+        val dto =
+            MemberInfoResponse(
+                accessToken = null,
+                name = member.name,
+                email = member.email,
+                picture = member.image,
+                isMember = true,
+                memberId = member.id,
+            )
+
+        dto.accessToken = jwtTokenProvider.createToken(member.id)
+        dto.refreshToken = tokenService.generateRefreshToken(member.id)
+        dto.memberId = member.id
+        dto.name = member.name
+
+        return dto
+    }
+
+    private fun validatePassword(request: NativeLoginRequest) {
+        if (request.password != password) {
+            throw BadRequestException(fieldName = "password", message = "비밀번호가 일치하지 않습니다.")
+        }
+    }
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 앱스토어 등록을 위해 임시적으로 자체 로그인을 구현했습니다.
- 비밀번호는 프로퍼티 파일에 박아뒀습니다.

---

### ✨ 참고 사항

- 해당 테스트 계정으로 소셜 로그인을 하면 이메일 중복 오류가 발생하므로 주의 필요!!

---

### ⏰ 현재 버그

x

---

### ✏ Git Close

- #248 
