### PR TITLE
Feat: production 용 cd workflow 구현

### DIFF
--- a/.github/workflows/production-cd.yml
+++ b/.github/workflows/production-cd.yml
@@ -1,0 +1,71 @@
+name: production-cd
+
+on:
+    push:
+        branches: [ 'release' ]
+
+permissions:
+    contents: read
+
+jobs:
+    build:
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v3
+            - name: Set up JDK 17
+              uses: actions/setup-java@v3
+              with:
+                  java-version: '17'
+                  distribution: 'temurin'
+
+
+            - name: Set up properties
+              run: |
+                  cd src/main
+                  mkdir resources
+                  cd resources
+                  touch application.properties
+                  echo "${{ secrets.PROD_APPLICATION }}" > application.properties
+                  cat application.properties
+
+              shell: bash
+
+
+            - name: Set up newrelic.yml
+              run: |
+                  cd newrelic
+                  touch newrelic.yml
+                  echo "${{ secrets.PROD_NEW_RELIC_FILE }}" | base64 --decode > newrelic.yml
+
+              shell: bash
+
+
+            - name: Grant execute permission for gradlew
+              run: chmod +x gradlew
+
+            - name: Build with Gradle
+              run: ./gradlew build -x test -x ktlintMainSourceSetCheck
+
+            - name: Docker build
+              run: |
+                  docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+                  docker build --no-cache -t app .
+                  docker tag app ${{ secrets.DOCKER_USERNAME }}/prod-phote:latest
+                  docker push ${{ secrets.DOCKER_USERNAME }}/prod-phote:latest
+
+            - name: Deploy
+              uses: appleboy/ssh-action@v0.1.4
+              env:
+                  COMPOSE: "/home/ubuntu/compose/docker-compose-dev.yml"
+              with:
+                  host: ${{ secrets.PROD_HOST }}
+                  username: ${{ secrets.USERNAME }}
+                  key: ${{ secrets.PROD_PRIVATE_KEY }}
+                  port: ${{ secrets.DEV_PORT }}
+                  envs: COMPOSE
+                  script: |
+                      sudo docker-compose -f $COMPOSE down --rmi all
+                      sudo docker pull ${{ secrets.DOCKER_USERNAME }}/prod-phote:latest
+                      sudo docker-compose -f $COMPOSE up -d


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- production 용 cd workflow를 구현했습니다.
- `release` 로 푸시할 때 작동합니다.

---

### ✨ 참고 사항

- 기존 로드밸런서를 새로 만든 **prod-phote-server** 인스턴스에 연결하고 기존 인스턴스와는 연결을 끊어서, 새로 만든 인스턴스가 `api.~` 도메인을 사용할 수 있도록 했습니다.
- 기존 인스턴스는 이제 `dev.~` 로 연결되며 따로 로드밸런서는 지정하지 않고 nginx 설정을 통해 80 -> 8080 포트포워딩을 했습니다. ➡️ route53을 통해 도메인과 ip주소를 직접 연결하는 방식을 사용했습니다.
  - (사용 중인 로드밸런서를 같이 쓰려니까.. 포트 8080번을 쓰는게 두 개라 뭔가 안될 것 같은 느낌..? 그래서 lb를 따로 쓰려니까 굳이인듯해서 nginx 를 이용했습니다. 사실 잘 모룹겠습니다)

- production 환경을 위한 Newrelic 파일 (`PROD_NEW_RELIC_FILE`) 을 추가했습니다.
- production 환경을 위한 프로퍼티 파일 (`PROD_APPLICATION`) 을 추가했습니다.
- ec2 배포 시에 사용되는 깃 시크릿은 `USERNAME` 과 `DEV_PORT` 는 development 환경과 동일하게 사용하면 된다고 생각해서 `PROD_HOST`, `PROD_PRIVATE_KEY` 만 따로 분리 했습니다. (노션에서 내용 확인 가능)

---

### ⏰ 현재 버그

- 실제 release 브랜치에 푸시해보고 이것저것 수정해야할게 생길지도..

---

### ✏ Git Close

- #250 