### PR TITLE
Feat: ReadExamResultDetail 구현

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
@@ -11,6 +11,7 @@ import com.swm_standard.phote.dto.RegradeExamResponse
 import com.swm_standard.phote.dto.ReadExamHistoryDetailResponse
 import com.swm_standard.phote.dto.ReadExamHistoryListResponse
 import com.swm_standard.phote.dto.ReadExamResultsResponse
+import com.swm_standard.phote.dto.ReadExamResultDetailResponse
 import com.swm_standard.phote.service.ExamService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -61,6 +62,19 @@ class ExamController(
         ) examId: UUID,
     ): BaseResponse<ReadExamResultsResponse> =
         BaseResponse(msg = "학생 시험 결과 조회 성공", data = examService.readExamResults(examId))
+
+    @Operation(summary = "readExamResultDetail", description = "(강사가) 학생의 시험 결과 상세조회")
+    @SecurityRequirement(name = "bearer Auth")
+    @GetMapping("/exam/result/{examId}/{memberId}")
+    fun readExamResultDetail(
+        @PathVariable(
+            required = true,
+        ) examId: UUID,
+        @PathVariable(
+            required = true,
+        ) memberId: UUID,
+    ): BaseResponse<ReadExamResultDetailResponse> =
+        BaseResponse(msg = "학생 시험 결과 상세조회 성공", data = examService.readExamResultDetail(examId, memberId))
 
     @Operation(summary = "gradeExam", description = "문제풀이 제출 및 채점")
     @SecurityRequirement(name = "bearer Auth")

--- a/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
@@ -60,7 +60,7 @@ data class ReadExamResultDetail(
 
 data class ReadExamResultDetailResponse(
     val examId: UUID,
-    val memberId: UUID,
+    val memberName: String,
     val totalCorrect: Int,
     val time: Int,
     val createdAt: LocalDateTime,

--- a/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
@@ -47,6 +47,26 @@ data class ReadExamResultsResponse(
     val students: List<ReadExamStudentResult>,
 )
 
+data class ReadExamResultDetail(
+    val statement: String,
+    val options: List<String>?,
+    val image: String?,
+    val category: Category,
+    val answer: String,
+    val submittedAnswer: String?,
+    val isCorrect: Boolean,
+    val sequence: Int,
+)
+
+data class ReadExamResultDetailResponse(
+    val examId: UUID,
+    val memberId: UUID,
+    val totalCorrect: Int,
+    val time: Int,
+    val createdAt: LocalDateTime,
+    val questions: List<ReadExamResultDetail>,
+)
+
 data class GradeExamRequest(
     val time: Int,
     val workbookId: UUID?,

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -149,9 +149,11 @@ class ExamService(
                 }
             }
 
+        val member = memberRepository.findById(memberId).orElseThrow { NotFoundException(fieldName = "memberId") }
+
         return ReadExamResultDetailResponse(
             examId = examId,
-            memberId = memberId,
+            memberName = member.name,
             totalCorrect = examResult.totalCorrect,
             time = examResult.time,
             questions = responses,

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -14,6 +14,8 @@ import com.swm_standard.phote.dto.ReadExamHistoryDetail
 import com.swm_standard.phote.dto.ReadExamHistoryDetailResponse
 import com.swm_standard.phote.dto.ReadExamHistoryListResponse
 import com.swm_standard.phote.dto.ReadExamResultsResponse
+import com.swm_standard.phote.dto.ReadExamResultDetail
+import com.swm_standard.phote.dto.ReadExamResultDetailResponse
 import com.swm_standard.phote.dto.ReadExamStudentResult
 import com.swm_standard.phote.dto.SubmittedAnswerRequest
 import com.swm_standard.phote.entity.Answer
@@ -81,7 +83,6 @@ class ExamService(
                 }
             }
 
-        // FIXME: 원래 createdAt 은 시험 생성일시임
         return ReadExamHistoryDetailResponse(
             examId = id,
             totalCorrect = examResult.totalCorrect,
@@ -123,6 +124,39 @@ class ExamService(
             }
 
         return ReadExamResultsResponse(examId, exam.workbook.quantity, responses)
+    }
+
+    fun readExamResultDetail(examId: UUID, memberId: UUID): ReadExamResultDetailResponse {
+        val examResult = examResultRepository.findByExamIdAndMemberId(examId, memberId)
+        val responses =
+            buildList {
+                examResult.answers.forEach { answer ->
+                    val question = answer.question
+                    if (question != null) {
+                        add(
+                            ReadExamResultDetail(
+                                statement = question.statement,
+                                options = question.options?.let { question.deserializeOptions() },
+                                image = question.image,
+                                category = question.category,
+                                answer = question.answer,
+                                submittedAnswer = answer.submittedAnswer,
+                                isCorrect = answer.isCorrect,
+                                sequence = answer.sequence,
+                            ),
+                        )
+                    }
+                }
+            }
+
+        return ReadExamResultDetailResponse(
+            examId = examId,
+            memberId = memberId,
+            totalCorrect = examResult.totalCorrect,
+            time = examResult.time,
+            questions = responses,
+            createdAt = examResult.createdAt,
+        )
     }
 
     @Transactional


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- readExamResultDetail 구현

---

### ✨ 참고 사항
- [명세서](https://www.notion.so/readExamResultDetail-d7d4550ebdc74a93b7be0a38e15db33a?pvs=4) 작성완료!
- 기존에 readExamHistoryDetail 리턴값 중에 createdAt에 달려있던 주석을 제거 했습니다. (문제 풀이 생성일 리턴하는게 맞아서!!)
- 테스트할 때, examId랑 memberId 적절한 값들을 잘 찾아 넣는게 좋습니다.. 중구난방인 데이터들이 많으요
---

### ⏰ 현재 버그

---

### ✏ Git Close #252 
