### PR TITLE
Feat: readAllSharedExams

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
@@ -6,12 +6,13 @@ import com.swm_standard.phote.dto.CreateSharedExamRequest
 import com.swm_standard.phote.dto.CreateSharedExamResponse
 import com.swm_standard.phote.dto.GradeExamRequest
 import com.swm_standard.phote.dto.GradeExamResponse
-import com.swm_standard.phote.dto.RegradeExamRequest
-import com.swm_standard.phote.dto.RegradeExamResponse
+import com.swm_standard.phote.dto.ReadAllSharedExamsResponse
 import com.swm_standard.phote.dto.ReadExamHistoryDetailResponse
 import com.swm_standard.phote.dto.ReadExamHistoryListResponse
-import com.swm_standard.phote.dto.ReadExamResultsResponse
 import com.swm_standard.phote.dto.ReadExamResultDetailResponse
+import com.swm_standard.phote.dto.ReadExamResultsResponse
+import com.swm_standard.phote.dto.RegradeExamRequest
+import com.swm_standard.phote.dto.RegradeExamResponse
 import com.swm_standard.phote.service.ExamService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -19,9 +20,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -112,4 +113,12 @@ class ExamController(
 
         return BaseResponse(data = CreateSharedExamResponse(sharedExamId), msg = "공유용 시험 생성 성공")
     }
+
+    @Operation(summary = "readAllSharedExams", description = "공유용 시험 목록 조회")
+    @SecurityRequirement(name = "bearer Auth")
+    @GetMapping("/exams")
+    fun readAllSharedExams(
+        @Parameter(hidden = true) @MemberId memberId: UUID,
+    ): BaseResponse<List<ReadAllSharedExamsResponse>> =
+        BaseResponse(data = examService.readAllSharedExams(memberId), msg = "공유용 시험 목록 조회 성공")
 }

--- a/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
@@ -2,6 +2,8 @@ package com.swm_standard.phote.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.swm_standard.phote.entity.Category
+import com.swm_standard.phote.entity.ExamStatus
+import com.swm_standard.phote.entity.ParticipationType
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Positive
 import java.time.LocalDateTime
@@ -120,4 +122,18 @@ data class CreateSharedExamRequest(
 
 data class CreateSharedExamResponse(
     val sharedExamId: UUID,
+)
+
+data class ReadAllSharedExamsResponse(
+    val examId: UUID,
+    val creator: String,
+    val title: String,
+    val startTime: LocalDateTime,
+    val endTime: LocalDateTime,
+    val status: ExamStatus,
+    val role: ParticipationType,
+    val capacity: Int? = null,
+    val examineeCount: Int? = null,
+    val totalCorrect: Int? = null,
+    val questionQuantity: Int? = null,
 )

--- a/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Exam.kt
@@ -20,7 +20,7 @@ data class Exam(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     val member: Member,
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "workbook_id")
     val workbook: Workbook,
     val sequence: Int,

--- a/src/main/kotlin/com/swm_standard/phote/entity/ExamStatus.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/ExamStatus.kt
@@ -1,0 +1,7 @@
+package com.swm_standard.phote.entity
+
+enum class ExamStatus {
+    NOT_STARTED,
+    IN_PROGRESS,
+    COMPLETED,
+}

--- a/src/main/kotlin/com/swm_standard/phote/entity/ParticipationType.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/ParticipationType.kt
@@ -1,0 +1,6 @@
+package com.swm_standard.phote.entity
+
+enum class ParticipationType {
+    CREATOR,
+    EXAMINEE,
+}

--- a/src/main/kotlin/com/swm_standard/phote/repository/ExamResultRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/ExamResultRepository.kt
@@ -6,6 +6,13 @@ import java.util.UUID
 
 interface ExamResultRepository : JpaRepository<ExamResult, UUID> {
     fun findByExamId(examId: UUID): ExamResult?
-    fun findByExamIdAndMemberId(examId: UUID, memberId: UUID): ExamResult
+
+    fun findByExamIdAndMemberId(
+        examId: UUID,
+        memberId: UUID,
+    ): ExamResult
+
     fun findAllByExamId(examId: UUID): List<ExamResult>
+
+    fun findAllByMemberId(memberId: UUID): List<ExamResult>
 }

--- a/src/main/kotlin/com/swm_standard/phote/repository/SharedExamRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/SharedExamRepository.kt
@@ -1,0 +1,9 @@
+package com.swm_standard.phote.repository
+
+import com.swm_standard.phote.entity.SharedExam
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface SharedExamRepository : JpaRepository<SharedExam, UUID> {
+    fun findAllByMemberId(memberId: UUID): List<SharedExam>
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- `readAllSharedExams` (사용자가 생성했거나, 응시한 공유용 시험 목록을 반환하는 기능) 을 구현했습니다.

---

### ✨ 참고 사항

- `examsAsCreator` => 공유용 시험만 딱 조회를 하면 돼서 `sharedExamRepository` 를 생성하고 이 레포에서 조회를 했습니다.
- `examsAsExaminee` => 이건 examResult를 먼저 조회하고 여기서 sharedExam에 대한 examResult만 추출했어야 했는데 처음엔 queryDSL 등으로 쿼리 선에서 추출을 마무리하고 싶었으나.... 멘토님이 제안해주신대로 일단 조회하고 필터링하는 것으로 구현했습니다. 
- workbook 까지 조회가 필요없는 경우라 `exam` 에서 `workbook`을 lazy fetching 하는 것으로 변경했습니다. 
- sharedExam의 시험 상태를 체크하는 메서드를 확장 함수로 구현했는데 이런건 테스트를 보통 어떻게 하는 편일까요? 멘토님께 나중에 물어보겠딤

---

### ⏰ 현재 버그

x

---

### ✏ Git Close

- #254 
