### PR TITLE
Feat: Nginx Blue/Green 무중단 배포 구현

### DIFF
--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -55,17 +55,24 @@ jobs:
                   docker tag app ${{ secrets.DOCKER_USERNAME }}/phote:latest
                   docker push ${{ secrets.DOCKER_USERNAME }}/phote:latest
 
-            - name: Deploy
-              uses: appleboy/ssh-action@v0.1.4
-              env:
-                  COMPOSE: "/home/ubuntu/compose/docker-compose-dev.yml"
+            - name: Send docker-compose.yml
+              uses: appleboy/scp-action@master
               with:
                   host: ${{ secrets.DEV_HOST }}
                   username: ${{ secrets.USERNAME }}
                   key: ${{ secrets.DEV_PRIVATE_KEY }}
                   port: ${{ secrets.DEV_PORT }}
-                  envs: COMPOSE
+                  source: "./docker-compose.yml"
+                  target: "/home/ubuntu/"
+
+            - name: Deploy
+              uses: appleboy/ssh-action@v0.1.4
+              with:
+                  host: ${{ secrets.DEV_HOST }}
+                  username: ${{ secrets.USERNAME }}
+                  key: ${{ secrets.DEV_PRIVATE_KEY }}
+                  port: ${{ secrets.DEV_PORT }}
                   script: |
-                      sudo docker-compose -f $COMPOSE down --rmi all
                       sudo docker pull ${{ secrets.DOCKER_USERNAME }}/phote:latest
-                      sudo docker-compose -f $COMPOSE up -d
+                      sudo chmod 777 ./deploy.sh
+                      sudo docker image prune -f

--- a/.github/workflows/production-cd.yml
+++ b/.github/workflows/production-cd.yml
@@ -55,17 +55,24 @@ jobs:
                   docker tag app ${{ secrets.DOCKER_USERNAME }}/prod-phote:latest
                   docker push ${{ secrets.DOCKER_USERNAME }}/prod-phote:latest
 
-            - name: Deploy
-              uses: appleboy/ssh-action@v0.1.4
-              env:
-                  COMPOSE: "/home/ubuntu/compose/docker-compose-dev.yml"
+            - name: Send docker-compose.yml
+              uses: appleboy/scp-action@master
               with:
                   host: ${{ secrets.PROD_HOST }}
                   username: ${{ secrets.USERNAME }}
                   key: ${{ secrets.PROD_PRIVATE_KEY }}
                   port: ${{ secrets.DEV_PORT }}
-                  envs: COMPOSE
+                  source: "./docker-compose.yml"
+                  target: "/home/ubuntu/"
+
+            - name: Deploy
+              uses: appleboy/ssh-action@v0.1.4
+              with:
+                  host: ${{ secrets.PROD_HOST }}
+                  username: ${{ secrets.USERNAME }}
+                  key: ${{ secrets.PROD_PRIVATE_KEY }}
+                  port: ${{ secrets.DEV_PORT }}
                   script: |
-                      sudo docker compose -f $COMPOSE down --rmi all
-                      sudo docker pull ${{ secrets.DOCKER_USERNAME }}/prod-phote:latest
-                      sudo docker compose -f $COMPOSE up -d
+                      docker pull ${{ secrets.DOCKER_USERNAME }}/prod-phote:latest
+                      sudo chmod 777 ./deploy.sh
+                      docker image prune -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,5 @@
 services:
-    redis:
-        image: redis:latest
-        container_name: myredis
-        restart: unless-stopped
-        volumes:
-            - /var/lib/docker/volumes/redis-volume/_data:/data
-        ports:
-            - "6379:6379"
-        environment:
-            - TZ=Asia/Seoul
-        hostname: redis
-        networks:
-            - phote-network
-
-    jarimage:
-        depends_on:
-            -   redis
+    blue:
         image: rinpark/phote:latest
         restart: unless-stopped
         container_name: myphote
@@ -23,6 +7,17 @@ services:
             - TZ=Asia/Seoul
         ports:
             - "8080:8080"
+        networks:
+            - phote-network
+
+    green:
+        image: rinpark/phote:latest
+        restart: unless-stopped
+        container_name: myphote
+        environment:
+            - TZ=Asia/Seoul
+        ports:
+            - "8081:8080"
         networks:
             - phote-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         environment:
             - TZ=Asia/Seoul
         ports:
-            - "8080:8080"
+            - "8082:8080"
         networks:
             - phote-network
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- prod 환경의 무중단 배포를 위해 nginx를 이용하여 Blue/Green 방식으로 구현했습니다.

---

### ✨ 참고 사항
- deploy.sh 는 깃허브에서 같이 형상관리를 할까.. 안전하게 인스턴스에 바로 작성해뒀습니다.
  - 노션 환경변수 페이지에 기록해뒀습니다.  
- 컴포즈 파일을 dev,  prod가 모두 동일하게 사용하므로 기존의 docker-compose-dev.yml 이름 대신 docker-compose.yml 로 변경했습니다.
- redis 컨테이너는 배포와 상관없이 계속 돌아가면 된다고 생각해서 compose 파일에서 제외하는 것을 제안합니다!

---

### ⏰ 현재 버그

(버그는 아니지만)
- redis 와 동일 네트워크로 연결돼있어야 해서 blue, green 모두 네트워크로 연결돼있는데 이런 경우에도 포트 번호를 같이 써도 되는지 확실하지 않습니다. (보통 포트를 중복으로 사용해도 된다고 함) 
  - 이는 develop 브랜치에서 확인을 한 후에 불가능하다면 compose 파일을 blue, green 으로 나눠서 레디스를 배포 때마다 해당 도커 네트워크에서 재구동해줘야할 것 같습니다.

---

### ✏ Git Close

- #258 
