### PR TITLE
Fix: readExamHistoryList 본인 시험만 조회하도록 수정

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
@@ -52,8 +52,9 @@ class ExamController(
         @PathVariable(
             required = true,
         ) workbookId: UUID,
+        @MemberId memberId: UUID,
     ): BaseResponse<List<ReadExamHistoryListResponse>> =
-        BaseResponse(msg = "문제풀이 기록 리스트 조회 성공", data = examService.readExamHistoryList(workbookId))
+        BaseResponse(msg = "문제풀이 기록 리스트 조회 성공", data = examService.readExamHistoryList(workbookId, memberId))
 
     @Operation(summary = "readExamResults", description = "(강사가) 학생들의 시험 결과 목록을 조회")
     @SecurityRequirement(name = "bearer Auth")

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -108,12 +108,11 @@ class ExamService(
         )
     }
 
-    fun readExamHistoryList(workbookId: UUID): List<ReadExamHistoryListResponse> {
+    fun readExamHistoryList(workbookId: UUID, memberId: UUID): List<ReadExamHistoryListResponse> {
         val exams = examRepository.findAllByWorkbookId(workbookId)
         return exams.map { exam ->
-            // FIXME: exam 마다 examResult 를 또 조회해야함 쿼리 개선 필요
             val examResult =
-                examResultRepository.findByExamId(exam.id!!) ?: throw NotFoundException(fieldName = "examResult")
+                examResultRepository.findByExamIdAndMemberId(exam.id!!, memberId)
 
             ReadExamHistoryListResponse(
                 examId = exam.id!!,

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -110,9 +110,11 @@ class ExamService(
 
     fun readExamHistoryList(workbookId: UUID, memberId: UUID): List<ReadExamHistoryListResponse> {
         val exams = examRepository.findAllByWorkbookId(workbookId)
-        return exams.map { exam ->
-            val examResult =
-                examResultRepository.findByExamIdAndMemberId(exam.id!!, memberId)
+
+        return exams.filter { exam ->
+            !sharedExamRepository.findById(exam.id!!).isPresent
+        }.map { exam ->
+            val examResult = examResultRepository.findByExamIdAndMemberId(exam.id!!, memberId)
 
             ReadExamHistoryListResponse(
                 examId = exam.id!!,

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -115,6 +115,7 @@ class ExamService(
             !sharedExamRepository.findById(exam.id!!).isPresent
         }.map { exam ->
             val examResult = examResultRepository.findByExamIdAndMemberId(exam.id!!, memberId)
+                ?: throw NotFoundException(fieldName = "examResult")
 
             ReadExamHistoryListResponse(
                 examId = exam.id!!,


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 기존 코드에서는 본인이 아닌 시험도 조회할 수 있는 코드여서 404가 에러가 발생함!
   - 만약, 선생님이 문제집을 공유하려고 시험을 생성해뒀다면 examId는 생겨서 조회가 되는데 `examResultRepository.findByExamId(exam.id!!) ?: throw NotFoundException(fieldName = "examResult")` 여기서 examResult가 없는 시나리오 발생 --> 404에러
   - 따라서, 해당 API는 본인의 시험 히스토리만 조회해야 하므로 memberID 확인 로직을 추가해주었읍니다
   - ~(이게 말이 잘 이해가 될지 모르겠네..)~

---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close #261 
