### PR TITLE
Feat: readExamHistoryList (시험 결과 목록 조회) 조회 성능 개선

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/entity/ExamResult.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/ExamResult.kt
@@ -3,6 +3,7 @@ package com.swm_standard.phote.entity
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -16,12 +17,13 @@ import java.util.UUID
 @SQLDelete(sql = "UPDATE exam_result SET deleted_at = NOW() WHERE exam_result_id = ?")
 data class ExamResult(
     @JoinColumn(name = "member_id")
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     val member: Member,
     val time: Int,
     @JoinColumn(name = "exam_id")
     @ManyToOne
     val exam: Exam,
+    val totalQuantity: Int,
 ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -33,8 +35,6 @@ data class ExamResult(
     @OneToMany(mappedBy = "examResult", cascade = [(CascadeType.REMOVE)])
     val answers: MutableList<Answer> = mutableListOf()
 
-    fun calculateTotalQuantity(): Int = answers.size
-
     fun increaseTotalCorrect(count: Int) {
         totalCorrect += count
     }
@@ -44,6 +44,7 @@ data class ExamResult(
             member: Member,
             time: Int,
             exam: Exam,
-        ) = ExamResult(member, time, exam)
+            totalQuantity: Int,
+        ) = ExamResult(member, time, exam, totalQuantity)
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/repository/examresultrepository/CustomExamResultRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/examresultrepository/CustomExamResultRepository.kt
@@ -1,0 +1,11 @@
+package com.swm_standard.phote.repository.examresultrepository
+
+import com.swm_standard.phote.entity.ExamResult
+import java.util.UUID
+
+interface CustomExamResultRepository {
+    fun findAllByExamIdListAndMemberId(
+        examIdList: List<UUID>,
+        memberId: UUID,
+    ): List<ExamResult>
+}

--- a/src/main/kotlin/com/swm_standard/phote/repository/examresultrepository/CustomExamResultRepositoryImpl.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/examresultrepository/CustomExamResultRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.swm_standard.phote.repository.examresultrepository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.swm_standard.phote.entity.ExamResult
+import com.swm_standard.phote.entity.QExamResult.examResult
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+class CustomExamResultRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory,
+) : CustomExamResultRepository {
+    override fun findAllByExamIdListAndMemberId(
+        examIdList: List<UUID>,
+        memberId: UUID,
+    ): List<ExamResult> =
+        jpaQueryFactory
+            .selectFrom(examResult)
+            .where(examResult.exam.id.`in`(examIdList))
+            .where(examResult.member.id.eq(memberId))
+            .fetch()
+}

--- a/src/main/kotlin/com/swm_standard/phote/repository/examresultrepository/ExamResultRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/examresultrepository/ExamResultRepository.kt
@@ -1,16 +1,18 @@
-package com.swm_standard.phote.repository
+package com.swm_standard.phote.repository.examresultrepository
 
 import com.swm_standard.phote.entity.ExamResult
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface ExamResultRepository : JpaRepository<ExamResult, UUID> {
+interface ExamResultRepository :
+    JpaRepository<ExamResult, UUID>,
+    CustomExamResultRepository {
     fun findByExamId(examId: UUID): ExamResult?
 
     fun findByExamIdAndMemberId(
         examId: UUID,
         memberId: UUID,
-    ): ExamResult
+    ): ExamResult?
 
     fun findAllByExamId(examId: UUID): List<ExamResult>
 

--- a/src/test/kotlin/com/swm_standard/phote/entity/ExamResultTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/ExamResultTest.kt
@@ -5,9 +5,7 @@ import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntr
 import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
 import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
 import com.navercorp.fixturemonkey.kotlin.setExp
-import com.navercorp.fixturemonkey.kotlin.sizeExp
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class ExamResultTest {
@@ -17,22 +15,6 @@ class ExamResultTest {
             .plugin(KotlinPlugin())
             .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
             .build()
-
-    @Test
-    fun `문제 풀이한 총 문제수를 구한다`() {
-        // given
-        val exam: ExamResult =
-            fixtureMonkey
-                .giveMeBuilder<ExamResult>()
-                .sizeExp(ExamResult::answers, 2)
-                .sample()
-
-        // when
-        val totalQuantity = exam.calculateTotalQuantity()
-
-        // then
-        assertEquals(totalQuantity, 2)
-    }
 
     @Test
     fun `totalCorrect가 증가한다`() {


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- readExamHistoryList 의 조회 성능을 개선하기 위해 일부 수정했습니다. (이전에 FIXME 항목에 적혀있었던 부분)
- totalQuantity 항목을 계산하기 위해 `calculateTotalQuantity()` 메서드를 사용했었는데 이때 answer 를 모두 조회해야하므로 지연이 생길 수 있었습니다. 문제 전체 개수는 변경되지 않기 때문에 exam을 생성할 때 answer 개수를 totalQuantity 에 담아 저장하도록 변경했습니다.
- `ExamResult` 엔티티에서 `member` 를 즉시 로딩할 필요가 없으므로 lazy fetch 설정했습니다.

---

### ✨ 참고 사항

- examId를 리스트로 모아서 examResult 들을 한꺼번에 조회하는 것이므로 이전 코드처럼 일일이 해당 exam에 매치되는 examResult 의 존재 여부는 확인할 수 없습니다. 따라서 전체 조회 후 examResult 개수와 exam 개수가 다른 케이스를 `examResultRepository.findByExamIdAndMemberId(examId, memberId)` 에서 null로 반환되는 케이스와 동일하게 간주하고 처리했습니다.

- 이슈와 관련없는 변경사항은 KtLint 자동 포맷입니당..

---

### ⏰ 현재 버그

x

---

### ✏ Git Close
- #266 
