### PR TITLE
Fix: searchQuestions 쿼리문 distinct 제거

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/repository/questionrepository/QuestionCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/questionrepository/QuestionCustomRepositoryImpl.kt
@@ -27,7 +27,6 @@ class QuestionCustomRepositoryImpl(
                 .where(question.member.id.eq(memberId))
                 .leftJoin(question.tags, tag)
                 .fetchJoin()
-                .distinct()
 
         // 태그 조건: tags로 들어온 태그들을 모두 포함하는 문제 검색
         if (!tags.isNullOrEmpty()) {


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- searchQuestionsList 기능에서 사용하는 쿼리문에서 `distinct` 를 제거했습니다.  
  - (https://github.com/swm-standard/phote-server/issues/268#issue-2630998774 이슈 내 코멘트 참고)

---

### ✨ 참고 사항

- 커밋에 코멘트를 달아서 알림이 잘 전달이 안됐을 수도 있겠다는 생각이 들어서.. 일단 제가 distinct 없애고 커밋 푸시했습니다이! 내가 구현한 부분이 아니라 잘못됐을 수도 있으니 컨펌받은 후에 롤백하거나 develop 으로 합치거나 할게용

---

### ⏰ 현재 버그

x

---

### ✏ Git Close

- #268 
