### PR TITLE
Feat: readAllSharedExam 응답에 workbookId 추가

### DIFF
--- a/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
+++ b/src/main/kotlin/com/swm_standard/phote/dto/ExamDtos.kt
@@ -126,6 +126,7 @@ data class CreateSharedExamResponse(
 
 data class ReadAllSharedExamsResponse(
     val examId: UUID,
+    val workbookId: UUID,
     val creator: String,
     val title: String,
     val startTime: LocalDateTime,

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -342,6 +342,7 @@ class ExamService(
                 ).map { exam ->
                 ReadAllSharedExamsResponse(
                     examId = exam.id!!,
+                    workbookId = exam.workbook.id,
                     creator = exam.member.name,
                     title = exam.title,
                     startTime = exam.startTime,
@@ -361,6 +362,7 @@ class ExamService(
                     val sharedExam = examResult.exam as SharedExam
                     ReadAllSharedExamsResponse(
                         examId = examResult.exam.id!!,
+                        workbookId = sharedExam.workbook.id,
                         creator = sharedExam.member.name,
                         title = sharedExam.title,
                         startTime = sharedExam.startTime,


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- `readAllSharedExam` 응답에 `workbookId` 를 추가했습니다.
- `readSharedExamInfo`는 없애지않고 혹시몰라 그대로 뒀습니다.

---

### ✨ 참고 사항

x

---

### ⏰ 현재 버그

x

---

### ✏ Git Close

- #270 
