### PR TITLE
GradeExam coroutine 리팩토링

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,4 +9,6 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 max_line_length = 120
 tab_width = 4
-disabled_rules = no-wildcard-imports, import-ordering, comment-spacing
+
+[*.{kt,kts}]
+ij_kotlin_packages_to_use_import_on_demand = unset

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     kotlin("jvm") version "1.9.24"
     kotlin("plugin.spring") version "1.9.24"
     id("jacoco")
+    id("org.jetbrains.dokka") version "1.9.20"
 
     // for querydsl
     kotlin("kapt") version "1.9.24"
@@ -67,6 +68,7 @@ dependencies {
     testImplementation("com.navercorp.fixturemonkey:fixture-monkey-kotlin:1.0.25")
     implementation("org.bouncycastle:bcpkix-jdk18on:1.75")
     implementation("com.nimbusds:nimbus-jose-jwt:9.12")
+    implementation("io.github.oshai:kotlin-logging-jvm:5.1.4")
 
     // querydsl
     implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+IS_GREEN=$(docker ps | grep green)
+DEFAULT_CONF=" /etc/nginx/nginx.conf"
+
+if [ -z $IS_GREEN  ];then
+
+  echo "### GREEN => BLUE ###"
+
+  echo "1. get blue image"
+  docker compose pull blue
+
+  echo "2. blue container up"
+  docker compose up -d blue
+
+  while [ 1 = 1 ]; do
+  echo "3. blue health check..."
+  sleep 3
+
+  REQUEST=$(curl ${server.address})
+    if [ -n "$REQUEST" ]; then
+            echo "health check success"
+            break ;
+            fi
+  done;
+
+  echo "4. reload nginx"
+  sudo cp /etc/nginx/nginx.blue.conf /etc/nginx/nginx.conf
+  sudo nginx -s rel
+
+  echo "5. green container down"
+  docker compose stop green
+else
+  echo "### BLUE => GREEN ###"
+
+  echo "1. get green image"
+  docker compose pull green
+
+  echo "2. green container up"

--- a/src/main/kotlin/com/swm_standard/phote/common/resolver/memberId/MemberIdResolver.kt
+++ b/src/main/kotlin/com/swm_standard/phote/common/resolver/memberId/MemberIdResolver.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.support.WebDataBinderFactory
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.method.support.ModelAndViewContainer
-import java.util.*
+import java.util.UUID
 
 @Component
 class MemberIdResolver(

--- a/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
+++ b/src/main/kotlin/com/swm_standard/phote/controller/ExamController.kt
@@ -7,11 +7,11 @@ import com.swm_standard.phote.dto.CreateSharedExamResponse
 import com.swm_standard.phote.dto.GradeExamRequest
 import com.swm_standard.phote.dto.GradeExamResponse
 import com.swm_standard.phote.dto.ReadAllSharedExamsResponse
-import com.swm_standard.phote.dto.ReadSharedExamInfoResponse
 import com.swm_standard.phote.dto.ReadExamHistoryDetailResponse
 import com.swm_standard.phote.dto.ReadExamHistoryListResponse
 import com.swm_standard.phote.dto.ReadExamResultDetailResponse
 import com.swm_standard.phote.dto.ReadExamResultsResponse
+import com.swm_standard.phote.dto.ReadSharedExamInfoResponse
 import com.swm_standard.phote.dto.RegradeExamRequest
 import com.swm_standard.phote.dto.RegradeExamResponse
 import com.swm_standard.phote.service.ExamService
@@ -29,12 +29,20 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
+/**
+ * Exam 관련 컨트롤러 클래스
+ */
 @RestController
 @RequestMapping("/api")
 @Tag(name = "Exam", description = "Exam API Document")
 class ExamController(
     private val examService: ExamService,
 ) {
+    /**
+     * 시험 기록 상세 조회 기능
+     * @param id 시험 id
+     * @return 시험 기록 상세 정보
+     */
     @Operation(summary = "readExamHistoryDetail", description = "문제풀이 기록 상세조회")
     @SecurityRequirement(name = "bearer Auth")
     @GetMapping("/exam/{id}")
@@ -82,7 +90,7 @@ class ExamController(
     @Operation(summary = "gradeExam", description = "문제풀이 제출 및 채점")
     @SecurityRequirement(name = "bearer Auth")
     @PostMapping("/exam")
-    fun gradeExam(
+    suspend fun gradeExam(
         @Valid @RequestBody request: GradeExamRequest,
         @Parameter(hidden = true) @MemberId memberId: UUID,
     ): BaseResponse<GradeExamResponse> {

--- a/src/main/kotlin/com/swm_standard/phote/entity/Answer.kt
+++ b/src/main/kotlin/com/swm_standard/phote/entity/Answer.kt
@@ -41,7 +41,8 @@ data class Answer(
         )
     }
 
-    fun checkMultipleAnswer() {
+    fun checkMultipleAnswer(): Boolean {
         isCorrect = submittedAnswer == question?.answer
+        return isCorrect
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/external/aws/S3Service.kt
+++ b/src/main/kotlin/com/swm_standard/phote/external/aws/S3Service.kt
@@ -6,7 +6,7 @@ import com.swm_standard.phote.common.exception.BadRequestException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
-import java.util.*
+import java.util.UUID
 
 @Component
 class S3Service(

--- a/src/main/kotlin/com/swm_standard/phote/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/swm_standard/phote/repository/MemberRepository.kt
@@ -3,7 +3,7 @@ package com.swm_standard.phote.repository
 import com.swm_standard.phote.entity.Member
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import java.util.*
+import java.util.UUID
 
 @Repository
 interface MemberRepository : JpaRepository<Member, UUID> {

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -27,6 +27,7 @@ import com.swm_standard.phote.entity.ExamResult
 import com.swm_standard.phote.entity.ExamStatus
 import com.swm_standard.phote.entity.Member
 import com.swm_standard.phote.entity.ParticipationType
+import com.swm_standard.phote.entity.Question
 import com.swm_standard.phote.entity.SharedExam
 import com.swm_standard.phote.entity.Workbook
 import com.swm_standard.phote.repository.AnswerRepository
@@ -36,10 +37,12 @@ import com.swm_standard.phote.repository.examrepository.ExamRepository
 import com.swm_standard.phote.repository.examresultrepository.ExamResultRepository
 import com.swm_standard.phote.repository.questionrepository.QuestionRepository
 import com.swm_standard.phote.repository.workbookrepository.WorkbookRepository
-import kotlinx.coroutines.CoroutineScope
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -57,6 +60,8 @@ private fun SharedExam.checkStatus(): ExamStatus =
     } else {
         ExamStatus.IN_PROGRESS
     }
+
+private val logger = KotlinLogging.logger {}
 
 @Service
 @Transactional(readOnly = true)
@@ -193,84 +198,37 @@ class ExamService(
     }
 
     @Transactional
-    fun gradeExam(
+    suspend fun gradeExam(
         request: GradeExamRequest,
         memberId: UUID,
-    ): GradeExamResponse {
+    ): GradeExamResponse = withContext(Dispatchers.IO + CoroutineName("gradeExam")) {
+        logger.info { "[${coroutineContext[CoroutineName.Key]}] : gradeExam 시작" }
         val member = findMember(memberId)
+        val exam = getOrCreateExam(request, memberId, member)
+        val examResult = createExamResult(member, request, exam)
 
-        val exam =
-            if (request.workbookId != null) {
-                val workbook = findWorkbook(request.workbookId)
-                isWorkbookOwner(workbook, memberId)
+        val questions = questionRepository.findAllByIdIn(request.answers.map { it.questionId })
+            .associateBy { it.id }
 
-                examRepository.save(
-                    Exam
-                        .createExam(
-                            member,
-                            workbook,
-                            examRepository.findMaxSequenceByWorkbookId(workbook) + 1,
-                        ),
-                )
-            } else {
-                (
-                    examRepository
-                        .findById(
-                            checkNotNull(request.examId),
-                        ).orElseThrow { NotFoundException(fieldName = "exam") }
-                        as SharedExam
-                    ).apply {
-                    validateSubmissionTime()
-                    increaseExamineeCount()
-                }
+        val answerResults = request.answers.mapIndexed { index, answer ->
+            async {
+                logger.info { "[${coroutineContext[CoroutineName.Key]}][answer: ${index + 1}] : gradeAnswer 시작" }
+                gradeAnswer(questions.getValue(answer.questionId), answer, examResult, index)
+            }
+        }.awaitAll()
+            .let {
+                answerRepository.saveAll(it)
             }
 
-        val examResult =
-            examResultRepository.save(
-                ExamResult.createExamResult(
-                    member = member,
-                    time = request.time,
-                    exam = exam,
-                    totalQuantity = request.answers.size,
-                ),
-            )
+        examResult.increaseTotalCorrect(answerResults.count { it.isCorrect })
+        examResultRepository.save(examResult)
 
-        var totalCorrect = 0
-
-        val questions =
-            questionRepository
-                .findAllByIdIn(request.answers.map { answer -> answer.questionId })
-                .associateBy { it.id }
-
-        val response =
-            request.answers.mapIndexed { index: Int, answer: SubmittedAnswerRequest ->
-                val question = questions.getValue(answer.questionId)
-
-                val savingAnswer: Answer =
-                    Answer.createAnswer(
-                        question = question,
-                        submittedAnswer = request.answers[index].submittedAnswer,
-                        examResult = examResult,
-                        sequence = index + 1,
-                    )
-
-                CoroutineScope(Dispatchers.IO).launch {
-                    if (savingAnswer.submittedAnswer == null) {
-                        savingAnswer.isCorrect = false
-                    } else {
-                        when (question.category) {
-                            Category.MULTIPLE -> savingAnswer.checkMultipleAnswer()
-                            Category.ESSAY ->
-                                savingAnswer.isCorrect =
-                                    async { gradeByChatGpt(savingAnswer) }.await()
-                        }
-                    }
-                    if (savingAnswer.isCorrect) {
-                        totalCorrect += 1
-                    }
-                }
-                val savedAnswer = answerRepository.save(savingAnswer)
-
+        logger.info { "[${coroutineContext[CoroutineName]}] : gradeExam 종료" }
+        GradeExamResponse(
+            examId = exam.id!!,
+            totalCorrect = examResult.totalCorrect,
+            questionQuantity = answerResults.size,
+            answers = answerResults.map { savedAnswer ->
                 AnswerResponse(
                     questionId = savedAnswer.question!!.id,
                     submittedAnswer = savedAnswer.submittedAnswer,
@@ -278,24 +236,7 @@ class ExamService(
                     isCorrect = savedAnswer.isCorrect,
                 )
             }
-
-        examResult.increaseTotalCorrect(totalCorrect)
-
-        return GradeExamResponse(
-            examId = exam.id!!,
-            totalCorrect = examResult.totalCorrect,
-            questionQuantity = response.size,
-            answers = response,
         )
-    }
-
-    private fun isWorkbookOwner(
-        workbook: Workbook,
-        memberId: UUID,
-    ) {
-        if (workbook.member.id != memberId) {
-            throw BadRequestException(fieldName = "member", "사용자가 소유한 시험이 아닙니다.")
-        }
     }
 
     @Transactional
@@ -404,18 +345,92 @@ class ExamService(
             NotFoundException(fieldName = "member")
         }
 
+    private suspend fun gradeAnswer(
+        question: Question,
+        answer: SubmittedAnswerRequest,
+        examResult: ExamResult,
+        index: Int
+    ): Answer {
+        val savingAnswer = Answer.createAnswer(
+            question = question,
+            submittedAnswer = answer.submittedAnswer,
+            examResult = examResult,
+            sequence = index + 1
+        )
+        savingAnswer.isCorrect = when {
+            savingAnswer.submittedAnswer == null -> false
+            question.category == Category.MULTIPLE -> savingAnswer.checkMultipleAnswer()
+            question.category == Category.ESSAY -> gradeByChatGpt(savingAnswer)
+            else -> throw BadRequestException(message = "ChatGPT 채점 오류")
+        }
+        logger.info { "[CoroutineName(########)][answer: ${index + 1}] : gradeAnswer 종료" }
+
+        return savingAnswer
+    }
+
     private suspend fun gradeByChatGpt(savingAnswer: Answer): Boolean {
         val chatGptRequest =
             ChatGPTRequest(model, savingAnswer.submittedAnswer!!, savingAnswer.question!!.answer)
 
-        val chatGPTResponse =
-            withContext(Dispatchers.IO) {
-                template.postForObject(url, chatGptRequest, ChatGPTResponse::class.java)
-            }
+        val chatGPTResponse = coroutineScope {
+            logger.info { "[${coroutineContext[CoroutineName.Key]}][answer: ${savingAnswer.sequence}] : chatgpt 시작" }
+            template.postForObject(url, chatGptRequest, ChatGPTResponse::class.java)
+        }
 
         return when (chatGPTResponse!!.choices[0].message.content) {
             "true" -> true
             else -> false
+        }
+    }
+
+    private fun createExamResult(
+        member: Member,
+        request: GradeExamRequest,
+        exam: Exam
+    ) = examResultRepository.save(
+        ExamResult.createExamResult(
+            member = member,
+            time = request.time,
+            exam = exam,
+            totalQuantity = request.answers.size,
+        ),
+    )
+
+    private fun getOrCreateExam(
+        request: GradeExamRequest,
+        memberId: UUID,
+        member: Member
+    ) = if (request.workbookId != null) {
+        val workbook = findWorkbook(request.workbookId)
+        isWorkbookOwner(workbook, memberId)
+
+        examRepository.save(
+            Exam
+                .createExam(
+                    member,
+                    workbook,
+                    examRepository.findMaxSequenceByWorkbookId(workbook) + 1,
+                ),
+        )
+    } else {
+        (
+            examRepository
+                .findById(
+                    checkNotNull(request.examId),
+                ).orElseThrow { NotFoundException(fieldName = "exam") }
+                as SharedExam
+            ).apply {
+            validateSubmissionTime()
+            increaseExamineeCount()
+        }
+    }
+
+    private fun isWorkbookOwner(
+        workbook: Workbook,
+        memberId: UUID,
+    ) {
+        if (workbook.member.id != memberId) {
+            throw BadRequestException(fieldName = "member", "사용자가 소유한 시험이 아닙니다.")
         }
     }
 }

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -42,12 +42,12 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.client.RestTemplate
+import java.lang.System.currentTimeMillis
 import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.jvm.optionals.getOrElse
@@ -201,8 +201,9 @@ class ExamService(
     suspend fun gradeExam(
         request: GradeExamRequest,
         memberId: UUID,
-    ): GradeExamResponse = withContext(Dispatchers.IO + CoroutineName("gradeExam")) {
-        logger.info { "[${coroutineContext[CoroutineName.Key]}] : gradeExam 시작" }
+    ): GradeExamResponse = withContext(Dispatchers.IO + CoroutineName("gradeExamV1")) {
+        val startTime = currentTimeMillis()
+        logger.info { "[${coroutineContext[CoroutineName]}] : gradeExam 시작" }
         val member = findMember(memberId)
         val exam = getOrCreateExam(request, memberId, member)
         val examResult = createExamResult(member, request, exam)
@@ -216,14 +217,13 @@ class ExamService(
                 gradeAnswer(questions.getValue(answer.questionId), answer, examResult, index)
             }
         }.awaitAll()
-            .let {
-                answerRepository.saveAll(it)
-            }
 
-        examResult.increaseTotalCorrect(answerResults.count { it.isCorrect })
+        val totalCorrect = answerResults.count { it.isCorrect }
+        examResult.increaseTotalCorrect(totalCorrect)
         examResultRepository.save(examResult)
 
         logger.info { "[${coroutineContext[CoroutineName]}] : gradeExam 종료" }
+        logger.info { "gradeExam 실행 시간: ${currentTimeMillis() - startTime}ms" }
         GradeExamResponse(
             examId = exam.id!!,
             totalCorrect = examResult.totalCorrect,
@@ -350,29 +350,30 @@ class ExamService(
         answer: SubmittedAnswerRequest,
         examResult: ExamResult,
         index: Int
-    ): Answer {
+    ): Answer = withContext(Dispatchers.IO) {
         val savingAnswer = Answer.createAnswer(
             question = question,
             submittedAnswer = answer.submittedAnswer,
             examResult = examResult,
             sequence = index + 1
         )
+
         savingAnswer.isCorrect = when {
             savingAnswer.submittedAnswer == null -> false
             question.category == Category.MULTIPLE -> savingAnswer.checkMultipleAnswer()
             question.category == Category.ESSAY -> gradeByChatGpt(savingAnswer)
             else -> throw BadRequestException(message = "ChatGPT 채점 오류")
         }
-        logger.info { "[CoroutineName(########)][answer: ${index + 1}] : gradeAnswer 종료" }
 
-        return savingAnswer
+        logger.info { "[${coroutineContext[CoroutineName.Key]}][answer: ${index + 1}] : gradeAnswer 종료" }
+        answerRepository.save(savingAnswer)
     }
 
     private suspend fun gradeByChatGpt(savingAnswer: Answer): Boolean {
         val chatGptRequest =
             ChatGPTRequest(model, savingAnswer.submittedAnswer!!, savingAnswer.question!!.answer)
 
-        val chatGPTResponse = coroutineScope {
+        val chatGPTResponse = withContext(Dispatchers.IO) {
             logger.info { "[${coroutineContext[CoroutineName.Key]}][answer: ${savingAnswer.sequence}] : chatgpt 시작" }
             template.postForObject(url, chatGptRequest, ChatGPTResponse::class.java)
         }

--- a/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/ExamService.kt
@@ -201,9 +201,10 @@ class ExamService(
     suspend fun gradeExam(
         request: GradeExamRequest,
         memberId: UUID,
-    ): GradeExamResponse = withContext(Dispatchers.IO + CoroutineName("gradeExamV1")) {
+    ): GradeExamResponse = withContext(Dispatchers.IO + CoroutineName("gradeExamV2")) {
         val startTime = currentTimeMillis()
-        logger.info { "[${coroutineContext[CoroutineName]}] : gradeExam 시작" }
+        logger.info { "[${coroutineContext[CoroutineName.Key]}] : gradeExam 시작" }
+
         val member = findMember(memberId)
         val exam = getOrCreateExam(request, memberId, member)
         val examResult = createExamResult(member, request, exam)
@@ -217,9 +218,11 @@ class ExamService(
                 gradeAnswer(questions.getValue(answer.questionId), answer, examResult, index)
             }
         }.awaitAll()
+            .let {
+                answerRepository.saveAll(it)
+            }
 
-        val totalCorrect = answerResults.count { it.isCorrect }
-        examResult.increaseTotalCorrect(totalCorrect)
+        examResult.increaseTotalCorrect(answerResults.count { it.isCorrect })
         examResultRepository.save(examResult)
 
         logger.info { "[${coroutineContext[CoroutineName]}] : gradeExam 종료" }
@@ -357,16 +360,15 @@ class ExamService(
             examResult = examResult,
             sequence = index + 1
         )
-
         savingAnswer.isCorrect = when {
             savingAnswer.submittedAnswer == null -> false
             question.category == Category.MULTIPLE -> savingAnswer.checkMultipleAnswer()
             question.category == Category.ESSAY -> gradeByChatGpt(savingAnswer)
             else -> throw BadRequestException(message = "ChatGPT 채점 오류")
         }
+        logger.info { "[CoroutineName(###########)][answer: ${index + 1}] : gradeAnswer 종료" }
 
-        logger.info { "[${coroutineContext[CoroutineName.Key]}][answer: ${index + 1}] : gradeAnswer 종료" }
-        answerRepository.save(savingAnswer)
+        savingAnswer
     }
 
     private suspend fun gradeByChatGpt(savingAnswer: Answer): Boolean {

--- a/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
+++ b/src/main/kotlin/com/swm_standard/phote/service/QuestionService.kt
@@ -18,9 +18,9 @@ import com.swm_standard.phote.repository.MemberRepository
 import com.swm_standard.phote.repository.TagRepository
 import com.swm_standard.phote.repository.questionrepository.QuestionRepository
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType

--- a/src/test/kotlin/com/swm_standard/phote/entity/QuestionSetTest.kt
+++ b/src/test/kotlin/com/swm_standard/phote/entity/QuestionSetTest.kt
@@ -20,7 +20,6 @@ class QuestionSetTest {
     fun `questionSet의 순서를 변경하는데 성공한다`() {
         val questionSet: QuestionSet = fixtureMonkey.giveMeOne()
         val newSequence = Arbitraries.integers().sample()
-
         questionSet.updateSequence(newSequence)
 
         assertEquals(newSequence, questionSet.sequence)


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- gradeExam 메서드를 suspend 함수로 전환하고, 전체 로직을 withContext(Dispatchers.IO +CoroutineName("gradeExamV2")) 내부에서 실행되도록 변경했습니다.
- 각 답안 채점 로직을 async로 병렬 처리한 후, awaitAll()을 통해 구조화된 방식으로 결과를 수집하고 저장하도록 리팩토링했습니다.
- OpenAI API 요청(gradeByChatGpt)을 명시적으로 withContext(Dispatchers.IO)에서 실행하도록 변경하여, IO 블로킹 작업이 적절한 스레드에서 실행되도록 보장했습니다.
- CoroutineName을 도입하여 각 채점 코루틴 및 전체 채점 프로세스에 대해 로깅을 강화했습니다.
- 전체 실행 시간을 측정하여 성능 모니터링이 가능하도록 개선했습니다.

#### 결과
<img width="508" alt="스크린샷 2025-04-09 오후 4 04 32" src="https://github.com/user-attachments/assets/ea516b2a-0fac-421e-9ac7-4d86e2168d4e" />


---

### ✨ 참고 사항

- EC2 인스턴스 내부에 있던 deploy.sh 스크립트 파일을 형상관리를 위해 GitHub에 푸시하겠습니다.
- 이외의 모든 변경파일은 `KtlintFormat`에 맞춰 변경된 파일입니다.


---

### ⏰ 현재 버그

x

---

### ✏ Git Close
- close #273 
